### PR TITLE
Location utilities

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -18,6 +18,7 @@ include("components/keywords.jl")
 include("components/lists.jl")
 include("components/operators.jl")
 include("components/strings.jl")
+include("location.jl")
 include("conversion.jl")
 include("display.jl")
 include("interface.jl")
@@ -96,7 +97,7 @@ function parse_compound(ps::ParseState, @nospecialize ret)
         ret = EXPR{head}(Any[ret, arg])
     elseif ps.nt.kind == Tokens.LPAREN
         no_ws = !isemptyws(ps.ws)
-        err_rng = ps.t.endbyte + 2:ps.nt.startbyte 
+        err_rng = ps.t.endbyte + 2:ps.nt.startbyte
         ret = @closeparen ps parse_call(ps, ret)
         if no_ws && !(ret isa UnaryOpCall || ret isa UnarySyntaxOpCall)
             push!(ps.errors, Error(err_rng, "White space in function call."))
@@ -141,7 +142,7 @@ end
 
 Parses an expression starting with a `(`.
 """
-@addctx :paren function parse_paren(ps::ParseState)  
+@addctx :paren function parse_paren(ps::ParseState)
     args = Any[PUNCTUATION(ps)]
     @closeparen ps @default ps @nocloser ps inwhere parse_comma_sep(ps, args, false, true, true)
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -262,7 +262,7 @@ function convert_expr(loc::Location, x::EXPR{x_Str})
         ret = Expr(:macrocall, name, nothing)
     end
     for i = 2:length(x.args)
-        push!(ret.args, x.args[i].val)
+        push!(ret.args, LocExpr(loc[i], x.args[i].val))
     end
     return ret
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -454,7 +454,7 @@ function convert_expr(loc::Location, x::EXPR{For})
         arg = Expr(:block)
         for (i, a) in enumerate(x.args[2].args)
             if !(a isa PUNCTUATION)
-                push!(arg.args, fix_range(loc[i], a))
+                push!(arg.args, fix_range(loc[2, i], a))
             end
         end
         push!(ret.args, arg)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -258,7 +258,8 @@ function convert_expr(loc::Location, x::EXPR{x_Str})
         mname.expr.args[2] = QuoteNode(Symbol("@", striploc(mname).args[2].value, "_str"))
         ret = Expr(:macrocall, mname, nothing)
     else
-        ret = Expr(:macrocall, Symbol("@", x.args[1].val, "_str"), nothing)
+        name = LocExpr(loc[1], Symbol("@", x.args[1].val, "_str"))
+        ret = Expr(:macrocall, name, nothing)
     end
     for i = 2:length(x.args)
         push!(ret.args, x.args[i].val)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -152,10 +152,10 @@ Expr(x::AbstractEXPR) = striploc(LocExpr(x))
 
 exprloc(x::LocExpr, i) = isempty(i) ? x.loc : exprloc(x.expr, i)
 
-exprloc(x::Expr, i) = isempty(i) ? error("No location information") :
+exprloc(x::Expr, i) = isempty(i) ? nothing :
   exprloc(x.args[i[1]], i[2:end])
 
-exprloc(x, i) = isempty(i) ? error("No location information") :
+exprloc(x, i) = isempty(i) ? nothing :
   error("Can't take index $i of $(repr(x))")
 
 exprloc(x::AbstractEXPR, i) = exprloc(LocExpr(x), i)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -213,9 +213,9 @@ function convert_expr(loc::Location, x::WhereOpCall)
     for i = 1:length(x.args)
         a = x.args[i]
         if a isa EXPR{Parameters}
-            insert!(ret.args, 2, convert_child(loc[i+1], a))
+            insert!(ret.args, 2, convert_child(loc[i+2], a))
         elseif !(a isa PUNCTUATION || a isa KEYWORD)
-            push!(ret.args, convert_child(loc[i+1], a))
+            push!(ret.args, convert_child(loc[i+2], a))
         end
     end
     return ret

--- a/src/location.jl
+++ b/src/location.jl
@@ -1,0 +1,35 @@
+struct Location
+  ii::Vector{Union{Int,Symbol}}
+end
+
+Location() = Location([])
+
+parent(l::Location) = Location(l.ii[1:end-1])
+Base.getindex(l::Location, i...) = Location([l.ii..., i...])
+
+Base.getindex(ex::EXPR, i::Integer) = ex.args[i]
+Base.getindex(ex::AbstractEXPR, i) = collect(ex)[i]
+
+function Base.getindex(ex::AbstractEXPR, l::Location)
+  for i in l.ii
+    ex = i isa Integer ? ex[i] : getproperty(ex, i)
+  end
+  return ex
+end
+
+# HACK
+index_in_collected(ex, k) = findfirst(x -> x === getproperty(ex, k), collect(ex))
+
+function charrange(ex::AbstractEXPR, l::Location)
+    o = 0
+    for i in l.ii
+      i isa Symbol && (i = index_in_collected(ex, i))
+      for j = 1:i-1
+        o += ex[j].fullspan
+      end
+      ex = ex[i]
+    end
+    full = o .+ (1:ex.fullspan)
+    inner = o .+ (1:ex.span)
+    return full, inner
+end

--- a/src/location.jl
+++ b/src/location.jl
@@ -7,8 +7,16 @@ Location() = Location([])
 parent(l::Location) = Location(l.ii[1:end-1])
 Base.getindex(l::Location, i...) = Location([l.ii..., i...])
 
+Base.getindex(ex::AbstractEXPR) = ex
 Base.getindex(ex::EXPR, i::Integer) = ex.args[i]
 Base.getindex(ex::AbstractEXPR, i) = collect(ex)[i]
+Base.getindex(ex::AbstractEXPR, i::Symbol) = getproperty(ex, i)
+
+Base.getindex(ex::AbstractEXPR, i, j...) = ex[i][j...]
+
+struct NoLoc end
+
+Base.getindex(l::NoLoc, i...) = l
 
 function Base.getindex(ex::AbstractEXPR, l::Location)
   for i in l.ii

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -87,7 +87,7 @@ end
     @test f("(a::T) -> a") == ["a"]
     @test f("(a,b) -> a") == ["a", "b"]
 
-    @test f("map(1:10) do a 
+    @test f("map(1:10) do a
         a
     end") == ["a"]
     @test f("map(1:10) do a,b
@@ -95,3 +95,17 @@ end
     end") == ["a", "b"]
 end
 
+function cstidx(s, i)
+  x = CSTParser.parse(s)
+  Expr(x[CSTParser.exprloc(x, i)])
+end
+
+@testset "inverse locations" begin
+  @test cstidx("f(a, b, c)", [3]) == :b
+  @test cstidx("\"\$x\"", [1]) == :x
+  @test cstidx("f(x) = 2x", [2, 1]) == :(2x)
+
+  @test cstidx("2x for x in X for y in Y", [1,1,1]) == :(2x)
+  @test cstidx("2x for x in X for y in Y", [1,2]) == :(x in X)
+  @test cstidx("2x for x in X for y in Y", [1,1,2]) == :(y in Y)
+end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -114,4 +114,5 @@ end
 
   @test cstidx(raw"a where {b}", [2]) == :b
   @test cstidx(raw"a where b", [2]) == :b
+  cstidx("for x in xs, y in ys end", [1,1]) == :(x in xs)
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -111,4 +111,7 @@ end
 
   @test cstidx("v\"1.1\"", [1]) == :v
   @test cstidx("v\"1.1\"", [3]) == "1.1"
+
+  @test cstidx(raw"a where {b}", [2]) == :b
+  @test cstidx(raw"a where b", [2]) == :b
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -110,4 +110,5 @@ end
   @test cstidx("2x for x in X for y in Y", [1,1,2]) == :(y in Y)
 
   @test cstidx("v\"1.1\"", [1]) == :v
+  @test cstidx("v\"1.1\"", [3]) == "1.1"
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -108,4 +108,6 @@ end
   @test cstidx("2x for x in X for y in Y", [1,1,1]) == :(2x)
   @test cstidx("2x for x in X for y in Y", [1,2]) == :(x in X)
   @test cstidx("2x for x in X for y in Y", [1,1,2]) == :(y in Y)
+
+  @test cstidx("v\"1.1\"", [1]) == :v
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 
 import CSTParser: parse, remlineinfo!, span, flisp_parse
 
+@testset "CSTParser" begin
+
 include("parser.jl")
 include("interface.jl")
 CSTParser.check_base()
+
+end


### PR DESCRIPTION
This patch adds the `Location` type which serves as an address, allowing CST nodes to be referenced in their context. This is useful for various CST operations including finding the absolute character range of a node, and finding a mapping between `Expr` and `EXPR` objects, addressing parts of #56.

Currently I think this needs to live in this repo because it's heavily tied to CSTParser's internal representation. If we could abstract over that some other way that allows us to build the mapping functionality on top, it could go somewhere else.

This is not complete yet, obviously, but if I get the go-ahead I'll find time to polish it.

```julia
julia> x = CSTParser.parse("f(a, b)");
julia> loc = CSTParser.expr_location(x, 3); # find Expr(x).args[3]
julia> x[loc]
ID: b  1 (1:1)

julia> CSTParser.charrange(x, loc)
(6:6, 6:6)
```