### PR TITLE
fix suffixed op conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.6.2"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
-Tokenize = "0.5.5"
+Tokenize = "0.5.6"
 julia = "1"
 
 [extras]

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -355,7 +355,7 @@ function parse_dot_mod(ps::ParseState, is_colon = false)
             push!(args, mPUNCTUATION(next(ps)))
         elseif isoperator(ps.nt) && (ps.nt.dotop || kindof(ps.nt) == Tokens.DOT)
             push!(args, mPUNCTUATION(Tokens.DOT, 1, 1))
-            ps.nt = RawToken(kindof(ps.nt), ps.nt.startpos, ps.nt.endpos, ps.nt.startbyte + 1, ps.nt.endbyte, ps.nt.token_error, false)
+            ps.nt = RawToken(kindof(ps.nt), ps.nt.startpos, ps.nt.endpos, ps.nt.startbyte + 1, ps.nt.endbyte, ps.nt.token_error, false, ps.nt.suffix)
         else
             break
         end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -133,7 +133,8 @@ function Expr(x::EXPR)
             return Symbol(lowercase(string(kindof(x))))
         end
     elseif isoperator(x)
-        return x.dot ? Symbol(:., UNICODE_OPS_REVERSE[kindof(x)]) : UNICODE_OPS_REVERSE[kindof(x)]
+        ret = x.val isa String ? Symbol(valof(x)) : UNICODE_OPS_REVERSE[kindof(x)]
+        return x.dot ? Symbol(:., ret) : ret
     elseif ispunctuation(x)
         return string(kindof(x))
     elseif isliteral(x)

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -162,7 +162,7 @@ mPUNCTUATION(kind, fullspan, span) = EXPR(PUNCTUATION, nothing, fullspan, span, 
 @noinline mPUNCTUATION(ps::ParseState) = EXPR(PUNCTUATION, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, kindof(ps.t), false, nothing, nothing, nothing, nothing)
 
 mOPERATOR(fullspan, span, kind, dotop) = EXPR(OPERATOR, nothing, fullspan, span, nothing, kind, dotop, nothing, nothing, nothing, nothing)
-@noinline mOPERATOR(ps::ParseState) = EXPR(OPERATOR, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, kindof(ps.t), ps.t.dotop, nothing, nothing, nothing, nothing)
+@noinline mOPERATOR(ps::ParseState) = EXPR(OPERATOR, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, ps.t.suffix ? val(ps.t, ps) : nothing, kindof(ps.t), ps.t.dotop, nothing, nothing, nothing, nothing)
 
 mKEYWORD(kind, fullspan, span) = EXPR(KEYWORD, nothing, fullspan, span, nothing, kind, false, nothing, nothing, nothing, nothing)
 @noinline mKEYWORD(ps::ParseState) = EXPR(KEYWORD, nothing, ps.nt.startbyte - ps.t.startbyte, ps.t.endbyte - ps.t.startbyte + 1, nothing, kindof(ps.t), false, nothing, nothing, nothing, nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ function closer(ps::ParseState)
     (ps.closer.inwhere && kindof(ps.nt) == Tokens.WHERE) ||
     (ps.closer.inwhere && ps.closer.ws && kindof(ps.t) == Tokens.RPAREN && isoperator(ps.nt) && precedence(ps.nt) < DeclarationOp) ||
     (ps.closer.precedence > WhereOp && (
-        kindof(ps.nt) == Tokens.LPAREN ||
+        (kindof(ps.nt) == Tokens.LPAREN && !(ps.t.kind === Tokens.EX_OR)) ||
         kindof(ps.nt) == Tokens.LBRACE ||
         kindof(ps.nt) == Tokens.LSQUARE ||
         (kindof(ps.nt) == Tokens.STRING && isemptyws(ps.ws)) ||

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -704,6 +704,7 @@ end""" |> test_expr
     @test "x\"\\\\ \"" |> test_expr
     @test "a.{1}" |> test_expr
     @test "@~" |> test_expr
+    @test "\$\$(x)" |> test_expr
 end
 
 @testset "interpolation error catching" begin


### PR DESCRIPTION
Fixes parsing/conversion of suffixed operators (e.g. `+ᴬ`), requires merging (and tagging) of https://github.com/JuliaLang/Tokenize.jl/pull/151. 