### PR TITLE
disable use of matchcloser (resulted in loops in list parsing)

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -43,14 +43,14 @@ function parse_expression(ps::ParseState)
         ps.errored = true
         ret = mErrorToken(mPUNCTUATION(next(ps)), UnexpectedToken)
     elseif kindof(ps.nt) ∈ term_c && !(kindof(ps.nt) === Tokens.END && ps.closer.square)
-        if match_closer(ps)
-            # trying to parse an expression but we've hit a token that closes a parent expression
-            ps.errored = true
-            ret = mErrorToken(MissingCloser)
-        else
+        # if match_closer(ps)
+        #     # trying to parse an expression but we've hit a token that closes a parent expression
+        #     ps.errored = true
+        #     ret = mErrorToken(MissingCloser)
+        # else
             ps.errored = true
             ret = mErrorToken(INSTANCE(next(ps)), UnexpectedToken)
-        end
+        # end
     else
         next(ps)
         if iskeyword(kindof(ps.t)) && kindof(ps.t) != Tokens.DO


### PR DESCRIPTION
This needs a rethink. Infinite loops were occurring where a closer (i.e. `end`, `]`, `)`, etc.) was unexpectedly hit but where that closer closed a parent expression (e.g. `[f(a_]` where the parser is at the underscore). The existing setup was attempting to create a fake closer token for the inner expression but this wasn't exiting loops within the list parsing code. 

I'll have a think on this, it may be best just to not bother trying to recover in these instances