### PR TITLE
Improve test output

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -430,6 +430,9 @@ function check_base(dir = dirname(Base.find_source_file("essentials.jl")), displ
         println(" : $neq    $(100 * neq / N)%", "  -  $aerr     $(100 * aerr / N)%")
         printstyled("base failed", color = :magenta)
         println(" : $bfail    $(100 * bfail / N)%")
+        println()
+    else
+        println("\r")
     end
     ret
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,10 @@ using Test
 
 import CSTParser: parse, remlineinfo!, span, flisp_parse, typof, kindof, valof
 
+@testset "CSTParser" begin
+
 include("parser.jl")
 include("interface.jl")
 CSTParser.check_base()
+
+end


### PR DESCRIPTION
This changes two things: a) test output is no longer weirdly misformatted when everything passes, and b) if everything passes the output is shorter.

Generally this makes it easier to look at the test output in the azure pipelines CI.