### PR TITLE
Fix ParseState.errored flag and add has_error() function

### DIFF
--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -50,14 +50,12 @@ function parse_kw(ps::ParseState)
         if ps.closer.square
             ret = mKEYWORD(ps)
         else
-            ret = mErrorToken(mIDENTIFIER(ps), UnexpectedToken)
-            ps.errored = true
+            ret = mErrorToken(ps, mIDENTIFIER(ps), UnexpectedToken)
         end
 
         return ret
     elseif k == Tokens.ELSE || k == Tokens.ELSEIF || k == Tokens.CATCH || k == Tokens.FINALLY
-        ps.errored = true
-        return mErrorToken(mIDENTIFIER(ps), UnexpectedToken)
+        return mErrorToken(ps, mIDENTIFIER(ps), UnexpectedToken)
     elseif k == Tokens.ABSTRACT
         return @default ps parse_abstract(ps)
     elseif k == Tokens.PRIMITIVE
@@ -73,8 +71,7 @@ function parse_kw(ps::ParseState)
     elseif k == Tokens.OUTER
         return mIDENTIFIER(ps)
     else
-        ps.errored = true
-        return mErrorToken(Unknown)
+        return mErrorToken(ps, Unknown)
     end
 end
 # Prefix
@@ -83,8 +80,7 @@ function parse_const(ps::ParseState)
     kw = mKEYWORD(ps)
     arg = parse_expression(ps)
     if !((typof(arg) === BinaryOpCall && kindof(arg.args[2]) === Tokens.EQ) || (typof(arg) === Global && typof(arg.args[2]) === BinaryOpCall && kindof(arg.args[2].args[2]) === Tokens.EQ))
-        ps.errored = true
-        arg = mErrorToken(arg, ExpectedAssignment)
+        arg = mErrorToken(ps, arg, ExpectedAssignment)
     end
     ret = EXPR(Const, EXPR[kw, arg])
     return ret
@@ -317,8 +313,7 @@ Parse an `if` block.
     # Parsing
     kw = mKEYWORD(ps)
     if kindof(ps.ws) == NewLineWS || kindof(ps.ws) == SemiColonWS
-        ps.errored = true
-        cond = mErrorToken(MissingConditional)
+        cond = mErrorToken(ps, MissingConditional)
     else
         cond = @closer ps :ws parse_expression(ps)
     end

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -13,8 +13,7 @@ function parse_tuple end
             if (isassignment(ps.nt) && kindof(ps.nt) != Tokens.APPROX)
                 push!(ret, op)
             elseif closer(ps)
-                ps.errored = true
-                push!(ret, mErrorToken(op, Unknown))
+                push!(ret, mErrorToken(ps, op, Unknown))
             else
                 nextarg = @closer ps :tuple parse_expression(ps)
                 if !(is_lparen(first(ret.args)))
@@ -28,8 +27,7 @@ function parse_tuple end
             if (isassignment(ps.nt) && kindof(ps.nt) != Tokens.APPROX)
                 ret = EXPR(TupleH, EXPR[ret, op])
             elseif closer(ps)
-                ps.errored = true
-                ret = mErrorToken(EXPR(TupleH, EXPR[ret, op]), Unknown)
+                ret = mErrorToken(ps, EXPR(TupleH, EXPR[ret, op]), Unknown)
             else
                 nextarg = @closer ps :tuple parse_expression(ps)
                 ret = EXPR(TupleH, EXPR[ret, op, nextarg])

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -120,7 +120,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
                     # Compared to flisp/JuliaParser, we have an extra lookahead token,
                     # so we need to back up one here
                 elseif Tokenize.Lexers.iswhitespace(peekchar(input)) || peekchar(input) === '#'
-                    push!(ret, mErrorToken(op, StringInterpolationWithTrailingWhitespace))
+                    push!(ret, mErrorToken(ps, op, StringInterpolationWithTrailingWhitespace))
                 else
                     pos = position(input)
                     ps1 = ParseState(input)
@@ -144,7 +144,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         # handle last String section
         lspan = position(b)
         if b.size == 0
-            ex = mErrorToken(Unknown)
+            ex = mErrorToken(ps, Unknown)
         else
             str = tostr(b)
             if istrip

--- a/src/recovery.jl
+++ b/src/recovery.jl
@@ -9,8 +9,7 @@ function accept_rparen(ps)
     if kindof(ps.nt) == Tokens.RPAREN
         return mPUNCTUATION(next(ps))
     else
-        ps.errored = true
-        return mErrorToken(mPUNCTUATION(Tokens.RPAREN, 0, 0), UnexpectedToken)
+        return mErrorToken(ps, mPUNCTUATION(Tokens.RPAREN, 0, 0), UnexpectedToken)
     end
 end
 accept_rparen(ps::ParseState, args) = push!(args, accept_rparen(ps))
@@ -19,8 +18,7 @@ function accept_rsquare(ps)
     if kindof(ps.nt) == Tokens.RSQUARE
         return mPUNCTUATION(next(ps))
     else
-        ps.errored = true
-        return mErrorToken(mPUNCTUATION(Tokens.RSQUARE, 0, 0), UnexpectedToken)
+        return mErrorToken(ps, mPUNCTUATION(Tokens.RSQUARE, 0, 0), UnexpectedToken)
     end
 end
 accept_rsquare(ps::ParseState, args) = push!(args, accept_rsquare(ps))
@@ -29,8 +27,7 @@ function accept_rbrace(ps)
     if kindof(ps.nt) == Tokens.RBRACE
         return mPUNCTUATION(next(ps))
     else
-        ps.errored = true
-        return mErrorToken(mPUNCTUATION(Tokens.RBRACE, 0, 0), UnexpectedToken)
+        return mErrorToken(ps, mPUNCTUATION(Tokens.RBRACE, 0, 0), UnexpectedToken)
     end
 end
 accept_rbrace(ps::ParseState, args) = push!(args, accept_rbrace(ps))
@@ -39,8 +36,7 @@ function accept_end(ps::ParseState)
     if kindof(ps.nt) == Tokens.END
         return mKEYWORD(next(ps))
     else
-        ps.errored = true
-        return mErrorToken(mKEYWORD(Tokens.END, 0, 0), UnexpectedToken)
+        return mErrorToken(ps, mKEYWORD(Tokens.END, 0, 0), UnexpectedToken)
     end
 end
 accept_end(ps::ParseState, args) = push!(args, accept_end(ps))
@@ -59,17 +55,13 @@ function recover_endmarker(ps)
         if !isempty(ps.closer.cc)
             closert = last(ps.closer.cc)
             if closert == :block
-                ps.errored = true
-                return mErrorToken(mKEYWORD(Tokens.END, 0, 0), Unknown)
+                return mErrorToken(ps, mKEYWORD(Tokens.END, 0, 0), Unknown)
             elseif closert == :paren
-                ps.errored = true
-                return mErrorToken(mPUNCTUATION(Tokens.RPAREN, 0, 0), Unknown)
+                return mErrorToken(ps, mPUNCTUATION(Tokens.RPAREN, 0, 0), Unknown)
             elseif closert == :square
-                ps.errored = true
-                return mErrorToken(mPUNCTUATION(Tokens.RSQUARE, 0, 0), Unknown)
+                return mErrorToken(ps, mPUNCTUATION(Tokens.RSQUARE, 0, 0), Unknown)
             elseif closert == :brace
-                ps.errored = true
-                return mErrorToken(mPUNCTUATION(Tokens.RBRACE, 0, 0), Unknown)
+                return mErrorToken(ps, mPUNCTUATION(Tokens.RBRACE, 0, 0), Unknown)
             end
         end
     end
@@ -77,8 +69,7 @@ end
 
 function requires_ws(x, ps)
     if x.span == x.fullspan
-        ps.errored = true
-        return mErrorToken(x, Unknown)
+        return mErrorToken(ps, x, Unknown)
     else
         return x
     end
@@ -88,8 +79,7 @@ function requires_no_ws(x, ps)
     if !(ps.nt.kind === Tokens.RPAREN ||
         ps.nt.kind === Tokens.RBRACE ||
         ps.nt.kind === Tokens.RSQUARE) && x.span != x.fullspan
-        ps.errored = true
-        return mErrorToken(x, UnexpectedWhiteSpace)
+        return mErrorToken(ps, x, UnexpectedWhiteSpace)
     else
         return x
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -244,7 +244,7 @@ Determine whether a parsing error occured while processing text with the given
 `ParseState`, or exists as a (sub) expression of `x`.
 """
 function has_error(x::EXPR)
-    return typof(x) == ErrorToken || (!isnothing(x.args) && any(has_error, x.args))
+    return typof(x) == ErrorToken || (x.args !== nothing && any(has_error, x.args))
 end
 has_error(ps::ParseState) = ps.errored
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -236,7 +236,17 @@ isajuxtaposition(ps::ParseState, ret::EXPR) = ((is_number(ret) && (isidentifier(
         ((kindof(ps.t) == Tokens.RPAREN || kindof(ps.t) == Tokens.RSQUARE) && (isidentifier(ps.nt) || kindof(ps.nt) == Tokens.CMD)) ||
         ((kindof(ps.t) == Tokens.STRING || kindof(ps.t) == Tokens.TRIPLE_STRING) && (kindof(ps.nt) == Tokens.STRING || kindof(ps.nt) == Tokens.TRIPLE_STRING)))) || ((kindof(ps.t) in (Tokens.INTEGER, Tokens.FLOAT) || kindof(ps.t) in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)) && isidentifier(ps.nt))
 
+"""
+    has_error(ps::ParseState)
+    has_error(x::EXPR)
 
+Determine whether a parsing error occured while processing text with the given
+`ParseState`, or exists as a (sub) expression of `x`.
+"""
+function has_error(x::EXPR)
+    return typof(x) == ErrorToken || (!isnothing(x.args) && any(has_error, x.args))
+end
+has_error(ps::ParseState) = ps.errored
 
 # When using the FancyDiagnostics package, Base.parse, is the
 # same as CSTParser.parse. Manually call the flisp parser here
@@ -354,7 +364,7 @@ function cst_parsefile(str)
         pop!(x.args)
     end
     x0 = norm_ast(Expr(x))
-    x0, ps.errored, sp
+    x0, has_error(ps), sp
 end
 
 function check_file(file, ret, neq)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -98,3 +98,11 @@ end
     end") == ["a", "b"]
 end
 
+@testset "has_error" begin
+    # Just an error token
+    @test CSTParser.has_error(CSTParser.parse(","))
+    # A nested ErrorToken
+    @test CSTParser.has_error(CSTParser.parse("foo(bar(\"\$ x\"))"))
+    # Not an error
+    @test !CSTParser.has_error(CSTParser.parse("foo(bar(\"\$x\"))"))
+end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -21,7 +21,7 @@ function test_expr(str, show_data = true)
 
     x0 = Expr(x)
     x1 = remlineinfo!(Meta.parse(str))
-    if ps.errored || x0 != x1
+    if CSTParser.has_error(ps) || x0 != x1
         if show_data
             println("Mismatch between flisp and CSTParser when parsing string $str")
             println("ParserState:\n $ps\n")


### PR DESCRIPTION
As mentioned on chat, the `errored` flag was not set correctly in various cases - fix this by
adding `ParseState` to `mErrorToken` function thereby making it much harder
to forget.

Also add a `has_error` function to access this information, and as a
utility to also determine whether a given `EXPR` has an error.