### PR TITLE
Compute text offsets in `show`

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -1,14 +1,15 @@
-function Base.show(io::IO, x::EXPR, d = 0, er = false)
+function Base.show(io::IO, x::EXPR, offset = 0, d = 0, er = false)
     T = typof(x)
     c =  T === ErrorToken || er ? :red : :normal
+    print(io, rpad(offset, 3), " ", rpad(x.fullspan, 3), " ", rpad(x.span, 3), "| ")
     if isidentifier(x)
-        printstyled(io, " "^d, typof(x) == NONSTDIDENTIFIER ? valof(x.args[2]) : valof(x), "  ", x.fullspan, "(", x.span, ") ", color = :yellow)
+        printstyled(io, " "^d, typof(x) == NONSTDIDENTIFIER ? valof(x.args[2]) : valof(x), color = :yellow)
         x.meta !== nothing && show(io, x.meta)
         println(io)
     elseif isoperator(x)
-        printstyled(io, " "^d, "OP: ", kindof(x), "  ", x.fullspan, "(", x.span, ")\n", color = c)
+        printstyled(io, " "^d, "OP: ", kindof(x), "\n", color = c)
     elseif iskw(x)
-        printstyled(io, " "^d, kindof(x), "  ", x.fullspan, "(", x.span, ")\n", color = :magenta)
+        printstyled(io, " "^d, kindof(x), "\n", color = :magenta)
     elseif ispunctuation(x)
         if kindof(x) == Tokens.LPAREN
             printstyled(io, " "^d, "(\n", color = c)
@@ -21,17 +22,22 @@ function Base.show(io::IO, x::EXPR, d = 0, er = false)
         elseif kindof(x) == Tokens.COMMA
             printstyled(io, " "^d, ",\n", color = c)
         else
-            printstyled(io, " "^d, "PUNC: ", kindof(x), "  ", x.fullspan, "(", x.span, ")\n", color = c)
+            printstyled(io, " "^d, "PUNC: ", kindof(x), "\n", color = c)
         end
     elseif isliteral(x)
-        printstyled(io, " "^d, "$(kindof(x)): ", valof(x), "  ", x.fullspan, "(", x.span, ")\n", color = c)
+        printstyled(io, " "^d, "$(kindof(x)): ", valof(x), "\n", color = c)
     else
-        printstyled(io, " "^d, T, "  ", x.fullspan, "(", x.span, ")", color = c)
-        x.meta !== nothing && show(io, x.meta)
+        printstyled(io, " "^d, T, color = c)
+        if x.meta !== nothing
+            print(io, "( ")
+            show(io, x.meta)
+            print(io, ")")
+        end
         println(io)
         x.args === nothing && return
         for a in x.args
-            show(io, a, d + 1, er)
+            show(io, a, offset, d + 1, er)
+            offset += a.fullspan
         end
     end
 end

--- a/test/display.jl
+++ b/test/display.jl
@@ -1,0 +1,18 @@
+@testset "show" begin
+    x = CSTParser.parse("a + (b*c) - d")
+    @test sprint(show, x) === """
+    0   13  13 | BinaryOpCall
+    0   10  9  |  BinaryOpCall
+    0   2   1  |   a
+    2   2   1  |   OP: PLUS
+    4   6   5  |   InvisBrackets
+    4   1   1  |    (
+    5   3   3  |    BinaryOpCall
+    5   1   1  |     b
+    6   1   1  |     OP: STAR
+    7   1   1  |     c
+    8   2   1  |    )
+    10  2   1  |  OP: MINUS
+    12  1   1  |  d
+    """
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ import CSTParser: parse, remlineinfo!, span, flisp_parse, typof, kindof, valof
 
 include("parser.jl")
 include("interface.jl")
+include("display.jl")
 CSTParser.check_base()
 
 end


### PR DESCRIPTION
This allows for a more global view of how the CST overlays onto the
source text, by explicitly computing and showing the offset along with
the spans.

The offsets and spans are left-justified into padded columns so that the
tree indentation remains correct (for spans < 1000 chars at least).

Columns are currently offset, fullspan and span.

Example:

![new_show](https://user-images.githubusercontent.com/601473/80479651-b0a42780-8992-11ea-8dc0-78991ccad256.png)
