### PR TITLE
show(::EXPR) refinement: print range in source string

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -1,7 +1,9 @@
 function Base.show(io::IO, x::EXPR, offset = 0, d = 0, er = false)
     T = typof(x)
     c =  T === ErrorToken || er ? :red : :normal
-    print(io, rpad(offset, 3), " ", rpad(x.fullspan, 3), " ", rpad(x.span, 3), "| ")
+    # Print span as 1-based range of the source string. This presentation is
+    # simple to understand when strings are presented to CSTParser.parse().
+    print(io, lpad(offset+1, 3), ":", rpad(offset+x.fullspan, 3), " ")
     if isidentifier(x)
         printstyled(io, " "^d, typof(x) == NONSTDIDENTIFIER ? valof(x.args[2]) : valof(x), color = :yellow)
         x.meta !== nothing && show(io, x.meta)

--- a/test/display.jl
+++ b/test/display.jl
@@ -1,18 +1,19 @@
 @testset "show" begin
     x = CSTParser.parse("a + (b*c) - d")
-    @test sprint(show, x) === """
-    0   13  13 | BinaryOpCall
-    0   10  9  |  BinaryOpCall
-    0   2   1  |   a
-    2   2   1  |   OP: PLUS
-    4   6   5  |   InvisBrackets
-    4   1   1  |    (
-    5   3   3  |    BinaryOpCall
-    5   1   1  |     b
-    6   1   1  |     OP: STAR
-    7   1   1  |     c
-    8   2   1  |    )
-    10  2   1  |  OP: MINUS
-    12  1   1  |  d
+    @test sprint(show, x) ===
+    """
+      1:13  BinaryOpCall
+      1:10   BinaryOpCall
+      1:2     a
+      3:4     OP: PLUS
+      5:10    InvisBrackets
+      5:5      (
+      6:8      BinaryOpCall
+      6:6       b
+      7:7       OP: STAR
+      8:8       c
+      9:10     )
+     11:12   OP: MINUS
+     13:13   d
     """
 end


### PR DESCRIPTION
Print EXPR (full)spans as 1-based range of the source string. This
presentation is much simpler to understand and use when considering EXPR spans
as an overlay of the input string compared to #167.

