### PR TITLE
Include loop-causing string in error

### DIFF
--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -94,7 +94,8 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         end
     else
         ret = EXPR(StringH, EXPR[], sfullspan, sspan)
-        input = IOBuffer(val(ps.t, ps))
+        str2 = val(ps.t, ps)
+        input = IOBuffer(str2)
         startbytes = istrip ? 3 : 1
         seek(input, startbytes)
         b = IOBuffer()
@@ -102,7 +103,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         while !eof(input)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop."))
+                throw(CSTInfiniteLoop("Inifite loop parsing: \"$str2\""))
             end
             c = read(input, Char)
             if c == '\\'


### PR DESCRIPTION
I think this is the quickest route to reproducing this.

When string literals are parsed we spin up a new ParseState context for any sections within that string which are interpolated - this commit includes that sub-string within out initinite loop error message.

