### PR TITLE
typo fixes, don't try to parse beyond end of file

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -219,7 +219,7 @@ function parse(ps::ParseState, cont = false)
         while kindof(ps.nt) !== Tokens.ENDMARKER
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             curr_line = ps.nt.startpos[1]
             ret = parse_doc(ps)
@@ -242,7 +242,7 @@ function parse(ps::ParseState, cont = false)
         if kindof(ps.nt) === Tokens.WHITESPACE || kindof(ps.nt) === Tokens.COMMENT
             next(ps)
             top = mLITERAL(ps.nt.startbyte, ps.nt.startbyte, "", Tokens.NOTHING)
-        else
+        elseif !(ps.done || kindof(ps.nt) === Tokens.ENDMARKER)
             curr_line = ps.nt.startpos[1]
             top = parse_doc(ps)
             if _continue_doc_parse(ps, top)
@@ -255,13 +255,15 @@ function parse(ps::ParseState, cont = false)
                 while kindof(ps.ws) == SemiColonWS && ps.nt.startpos[1] == last_line && kindof(ps.nt) != Tokens.ENDMARKER
                     safetytrip += 1
                     if safetytrip > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                        throw(CSTInfiniteLoop("Infinite loop at $ps"))
                     end
                     ret = parse_doc(ps)
                     push!(top, ret)
                     last_line = ps.nt.startpos[1]
                 end
             end
+        else
+            top = EXPR(ErrorToken, EXPR[], 0, 0)
         end
     end
 

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -10,7 +10,7 @@ function parse_block(ps::ParseState, ret::Vector{EXPR} = EXPR[], closers = (Toke
         safetytrip += 1
         if safetytrip > 10_000
             # Not needed, we take a take a token or break the loop for each branch.
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         if kindof(ps.nt) ∈ term_c # error handling if an unexpected closer is hit
             if kindof(ps.nt) === Tokens.ENDMARKER
@@ -74,7 +74,7 @@ function parse_iterators(ps::ParseState, allowfilter = false)
         while iscomma(ps.nt)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             accept_comma(ps, arg)
             nextarg = parse_iterator(ps)
@@ -152,7 +152,7 @@ function parse_comma_sep(ps::ParseState, args::Vector{EXPR}, kw = true, block = 
         starting_offset = ps.t.startbyte
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         a = parse_expression(ps)
         if kw && _do_kw_convert(ps, a)
@@ -166,7 +166,7 @@ function parse_comma_sep(ps::ParseState, args::Vector{EXPR}, kw = true, block = 
         end
         if ps.t.startbyte == starting_offset
             # We've not progressed over the course of a loop.
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
     end
     if istuple && length(args) > 2
@@ -188,7 +188,7 @@ function parse_comma_sep(ps::ParseState, args::Vector{EXPR}, kw = true, block = 
                 @nocloser ps :newline @closer ps :comma while @nocloser ps :semicolon !closer(ps)
                     safetytrip += 1
                     if safetytrip > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                        throw(CSTInfiniteLoop("Infinite loop at $ps"))
                     end
                     a = parse_expression(ps)
                     push!(args1, a)
@@ -215,7 +215,7 @@ function parse_parameters(ps::ParseState, args::Vector{EXPR}, args1::Vector{EXPR
     @nocloser ps :inwhere @nocloser ps :newline  @closer ps :comma while !isfirst || (@nocloser ps :semicolon !closer(ps))
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         if isfirst
             a = parse_expression(ps)
@@ -265,7 +265,7 @@ function parse_macrocall(ps::ParseState)
         while kindof(ps.nt) === Tokens.DOT
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             op = mOPERATOR(next(ps))
             nextarg = mIDENTIFIER(next(ps))
@@ -284,7 +284,7 @@ function parse_macrocall(ps::ParseState)
         @default ps while !closer(ps)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             if insquare
                 a = @closer ps :insquare @closer ps :inmacro @closer ps :ws @closer ps :wsop parse_expression(ps)
@@ -334,7 +334,7 @@ function parse_dot_mod(ps::ParseState, is_colon = false)
     while kindof(ps.nt) === Tokens.DOT || kindof(ps.nt) === Tokens.DDOT || kindof(ps.nt) === Tokens.DDDOT
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         d = mOPERATOR(next(ps))
         trailing_ws = d.fullspan - d.span
@@ -362,7 +362,7 @@ function parse_dot_mod(ps::ParseState, is_colon = false)
     while true
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         if kindof(ps.nt) === Tokens.AT_SIGN
             at = mPUNCTUATION(next(ps))

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -168,7 +168,7 @@ function parse_imports(ps::ParseState)
         while iscomma(ps.nt)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             accept_comma(ps, ret)
             arg = parse_dot_mod(ps, true)
@@ -180,7 +180,7 @@ function parse_imports(ps::ParseState)
         while iscomma(ps.nt)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             accept_comma(ps, ret)
             arg = parse_dot_mod(ps)
@@ -199,7 +199,7 @@ function parse_export(ps::ParseState)
     while iscomma(ps.nt)
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         push!(args, mPUNCTUATION(next(ps)))
         arg = parse_dot_mod(ps)[1]
@@ -229,7 +229,7 @@ function parse_blockexpr_sig(ps::ParseState, head)
         while kindof(ps.nt) === Tokens.WHERE && kindof(ps.ws) != Tokens.NEWLINE_WS
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             sig = @closer ps :inwhere @closer ps :ws parse_operator_where(ps, sig, INSTANCE(next(ps)), false)
         end
@@ -245,7 +245,7 @@ function parse_blockexpr_sig(ps::ParseState, head)
                 while iscomma(ps.nt)
                     safetytrip += 1
                     if safetytrip > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                        throw(CSTInfiniteLoop("Infinite loop at $ps"))
                     end
                     accept_comma(ps, arg)
                     startbyte = ps.nt.startbyte
@@ -261,7 +261,7 @@ function parse_blockexpr_sig(ps::ParseState, head)
         @closer ps :comma @closer ps :block while !closer(ps)
             safetytrip += 1
             if safetytrip > 10_000
-                throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                throw(CSTInfiniteLoop("Infinite loop at $ps"))
             end
             @closer ps :ws a = parse_expression(ps)
             push!(sig, a)

--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -116,7 +116,7 @@ function parse_array(ps::ParseState, isref = false)
             while kindof(ps.nt) !== Tokens.RSQUARE && kindof(ps.nt) !== Tokens.ENDMARKER
                 safetytrip += 1
                 if safetytrip > 10_000
-                    throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                    throw(CSTInfiniteLoop("Infinite loop at $ps"))
                 end
                 a = @closesquare ps  parse_expression(ps)
                 push!(ret, a)
@@ -131,7 +131,7 @@ function parse_array(ps::ParseState, isref = false)
             while kindof(ps.nt) !== Tokens.RSQUARE && kindof(ps.ws) !== NewLineWS && kindof(ps.ws) !== SemiColonWS && kindof(ps.nt) !== Tokens.ENDMARKER
                 safetytrip += 1
                 if safetytrip > 10_000
-                    throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                    throw(CSTInfiniteLoop("Infinite loop at $ps"))
                 end
                 a = @closesquare ps @closer ps :ws @closer ps :wsop parse_expression(ps)
                 push!(first_row, a)
@@ -155,7 +155,7 @@ function parse_array(ps::ParseState, isref = false)
                 while kindof(ps.nt) !== Tokens.RSQUARE && kindof(ps.nt) !== Tokens.ENDMARKER
                     safetytrip += 1
                     if safetytrip > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                        throw(CSTInfiniteLoop("Infinite loop at $ps"))
                     end
                     first_arg = @closesquare ps @closer ps :ws @closer ps :wsop parse_expression(ps)
                     push!(ret, EXPR(Row, EXPR[first_arg]))
@@ -163,7 +163,7 @@ function parse_array(ps::ParseState, isref = false)
                     while kindof(ps.nt) !== Tokens.RSQUARE && kindof(ps.ws) !== NewLineWS && kindof(ps.ws) !== SemiColonWS && kindof(ps.nt) !== Tokens.ENDMARKER
                         safetytrip1 += 1
                         if safetytrip1 > 10_000
-                            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                            throw(CSTInfiniteLoop("Infinite loop at $ps"))
                         end
                         a = @closesquare ps @closer ps :ws @closer ps :wsop parse_expression(ps)
                         push!(last(ret.args), a)
@@ -273,7 +273,7 @@ function parse_barray(ps::ParseState)
             while kindof(ps.nt) != Tokens.RBRACE && kindof(ps.nt) !== Tokens.ENDMARKER
                 safetytrip += 1
                 if safetytrip > 10_000
-                    throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                    throw(CSTInfiniteLoop("Infinite loop at $ps"))
                 end
                 a = @closebrace ps  parse_expression(ps)
                 push!(ret, a)
@@ -287,7 +287,7 @@ function parse_barray(ps::ParseState)
             while kindof(ps.nt) !== Tokens.RBRACE && kindof(ps.ws) !== NewLineWS && kindof(ps.ws) !== SemiColonWS && kindof(ps.nt) !== Tokens.ENDMARKER
                 safetytrip += 1
                 if safetytrip > 10_000
-                    throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                    throw(CSTInfiniteLoop("Infinite loop at $ps"))
                 end
                 a = @closebrace ps @closer ps :ws @closer ps :wsop parse_expression(ps)
                 push!(first_row, a)
@@ -310,7 +310,7 @@ function parse_barray(ps::ParseState)
                 while kindof(ps.nt) != Tokens.RBRACE
                     safetytrip += 1
                     if safetytrip > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                        throw(CSTInfiniteLoop("Infinite loop at $ps"))
                     end
                     if kindof(ps.nt) === Tokens.ENDMARKER
                         break
@@ -321,7 +321,7 @@ function parse_barray(ps::ParseState)
                     while kindof(ps.nt) !== Tokens.RBRACE && kindof(ps.ws) !== NewLineWS && kindof(ps.ws) !== SemiColonWS && kindof(ps.nt) !== Tokens.ENDMARKER
                         safetytrip1 += 1
                         if safetytrip1 > 10_000
-                            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+                            throw(CSTInfiniteLoop("Infinite loop at $ps"))
                         end
                         a = @closebrace ps @closer ps :ws @closer ps :wsop parse_expression(ps)
                         push!(last(ret.args), a)

--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -41,7 +41,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
             while nextind(str, idxend) - 1 < sizeof(str) && (lcp === nothing || !isempty(lcp))
                 safetytrip += 1
                 if safetytrip > 10_000
-                    throw(CSTInfiniteLoop("Inifite loop."))
+                    throw(CSTInfiniteLoop("Infinite loop."))
                 end
                 idxend = skip_to_nl(str, idxend)
                 idxstart = nextind(str, idxend)
@@ -49,7 +49,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
                 while nextind(str, idxend) - 1 < sizeof(str)
                     safetytrip1 += 1
                     if safetytrip1 > 10_000
-                        throw(CSTInfiniteLoop("Inifite loop."))
+                        throw(CSTInfiniteLoop("Infinite loop."))
                     end
                     c = str[nextind(str, idxend)]
                     if c == ' ' || c == '\t'
@@ -103,7 +103,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed = false)
         while !eof(input)
             safetytrip += 1
             if safetytrip > length(str2) # This is iterating over characters, not parsed expressions - 10,000 was in inappropriate limit.
-                throw(CSTInfiniteLoop("Inifite loop parsing: \"$str2\""))
+                throw(CSTInfiniteLoop("Infinite loop parsing: \"$str2\""))
             end
             c = read(input, Char)
             if c == '\\'

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -53,7 +53,7 @@ function ParseState(str::Union{IO,String}, loc::Int)
     while ps.nt.startbyte < loc
         safetytrip += 1
         if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))
+            throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end
         next(ps)
     end


### PR DESCRIPTION
Could fix the LanguageServer memory leak. Also fixes a typo.