### PR TITLE
Fix quoted nonstd ids (:var"sdf"), fix inf-loop check

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -92,7 +92,7 @@ function parse_compound(ps::ParseState, ret::EXPR)
     elseif (typof(ret) === x_Str || typof(ret) === x_Cmd) && isidentifier(ps.nt)
         arg = mIDENTIFIER(next(ps))
         push!(ret, mLITERAL(arg.fullspan, arg.span, val(ps.t, ps), Tokens.STRING))
-    elseif (isidentifier(ret) || is_getfield(ret)) && isprefixableliteral(ps.nt)
+    elseif (isidentifier(ret) || is_getfield(ret)) && isemptyws(ps.ws) && isprefixableliteral(ps.nt)
         next(ps)
         arg = parse_string_or_cmd(ps, ret)
         if kindof(arg) === Tokens.CMD || kindof(arg) === Tokens.TRIPLE_CMD

--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -147,13 +147,8 @@ Parses a comma separated list, optionally allowing for conversion of
 assignment (`=`) expressions to `Kw`.
 """
 function parse_comma_sep(ps::ParseState, args::Vector{EXPR}, kw = true, block = false, istuple = false)
-    safetytrip = 0
     @nocloser ps :inwhere @nocloser ps :newline @closer ps :comma while !closer(ps)
         starting_offset = ps.t.startbyte
-        safetytrip += 1
-        if safetytrip > 10_000
-            throw(CSTInfiniteLoop("Infinite loop at $ps"))
-        end
         a = parse_expression(ps)
         if kw && _do_kw_convert(ps, a)
             a = _kw_convert(a)
@@ -164,7 +159,7 @@ function parse_comma_sep(ps::ParseState, args::Vector{EXPR}, kw = true, block = 
         else# if kindof(ps.ws) == SemiColonWS
             break
         end
-        if ps.t.startbyte == starting_offset
+        if ps.t.startbyte <= starting_offset
             # We've not progressed over the course of a loop.
             throw(CSTInfiniteLoop("Infinite loop at $ps"))
         end

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -217,7 +217,6 @@ function parse_unary_colon(ps::ParseState, op::EXPR)
     elseif closer(ps)
         ret = op
     else
-        @info 1
         prev_errored = ps.errored
         arg = @precedence ps 20 parse_expression(ps)
         if isbracketed(arg)  && typof(arg.args[2]) === ErrorToken && errorof(arg.args[2]) === UnexpectedAssignmentOp

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -852,4 +852,8 @@ end""" |> test_expr
         end""")
         @test typof(x[2][1][1]) === CSTParser.GlobalRefDoc
     end
+
+    @testset "issue #198" begin
+        @test test_expr(":var\"id\"")
+    end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -852,8 +852,9 @@ end""" |> test_expr
         end""")
         @test typof(x[2][1][1]) === CSTParser.GlobalRefDoc
     end
-
-    @testset "issue #198" begin
-        @test test_expr(":var\"id\"")
+    if VERSION > v"1.3.0-" 
+        @testset "issue #198" begin
+            @test test_expr(":var\"id\"")
+        end
     end
 end


### PR DESCRIPTION
Fix #198 (parse error for quoted non standard symbols,  `:var"something"`).

Also fixes a loop check to allow comma separated lists of > 10000 elements.