### PR TITLE
improve loop checks

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -49,13 +49,10 @@ end
 
 function ParseState(str::Union{IO,String}, loc::Int)
     ps = ParseState(str)
-    prev_pos = -1  # TODO: remove
+    prevpos = position(ps)
     while ps.nt.startbyte < loc
-        if prev_pos == ps.nt.startbyte  # TODO: remove
-            throw(CSTInfiniteLoop("Inifite loop at $ps"))  # TODO: remove
-        end  # TODO: remove
-        prev_pos = ps.nt.startbyte # TODO: remove
         next(ps)
+        prevpos = loop_check(ps, prevpos)
     end
     return ps
 end
@@ -97,6 +94,7 @@ function Base.seek(ps::ParseState, offset)
     next(next(ps))
 end
 
+Base.position(ps::ParseState) = ps.nt.startbyte
 
 """
     lex_ws_comment(l::Lexer, c)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -712,3 +712,11 @@ Is `x` a binary call for `+` or `*` that can be extended to include more
 arguments?
 """
 can_become_chain(x::EXPR, op::EXPR) = isbinarycall(x) && (is_star(op) || is_plus(op)) && kindof(op) == kindof(x.args[2]) && !x.args[2].dot && x.args[2].span > 0
+
+function loop_check(ps, prevpos)
+    if position(ps) <= prevpos
+        throw(CSTInfiniteLoop("Infinite loop at $ps"))
+    else
+        position(ps)
+    end
+end


### PR DESCRIPTION
Checks that we are actually progressing along the input text (source code) in all `while` loops - i.e. that there is no case where we accidentally seek backwards.  The previous approach was poor.