### PR TITLE
fix reparse and quick_comp

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -468,6 +468,7 @@ end
 
 function minimal_reparse(s0, s1, x0 = CSTParser.parse(s0, true), x1 = CSTParser.parse(s1, true); inds = false)
     isempty(x0.args) && return inds ? (1:0, 1:length(x1.args), 1:0) : x1
+    x1.fullspan == 0 && return inds ? (1:0, 1:0, 1:0) : x1
     i0 = firstdiff(s0, s1)
     i1, i2 = revfirstdiff(s0, s1)
     # Find unaffected expressions at start


### PR DESCRIPTION
This isn't integral to CSTParser functioning but tt would be really helpful if someone could do a quick sense check of this. The motivation is to allow us identify (cheaply) which expressions have changed and which can be retained after modifying a string. 

`i1 = firstdiff(s1, s2)` and `i2, i3 = revfirstdiff(s1, s2)` find the byte offsets that enclose the areas of the string that have changed so that `s1[1:i1] == s2[1:i1]` and `s1[i2:end] == s2[i3:end]`.

`minimal_reparse(s1, s2, x1 = parse(s1), x2 = parse(s2))` then returns a CST for s2 that reuses as many nodes from x1 as possible or (`inds = true`) the relevant indices for the first group of args from x1, the second from x2 (that represent the changes), and the trailing group from x1 that can be reused.