### PR TITLE
malformed uint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
-Tokenize = "0.5.7"
+Tokenize = "0.5.11"
 
 [targets]
 test = ["Test"]

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -895,4 +895,7 @@ end""" |> test_expr
             @test CSTParser.ismacroname(CSTParser.parse(s).args[1])
         end
     end
+    @testset "bad uint" begin
+            @test Expr(CSTParser.parse("0x.")) == Expr(:error)
+        end
 end


### PR DESCRIPTION
Tests won't pass until new Tokenize version