### PR TITLE
index fix

### DIFF
--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -116,7 +116,7 @@ function parse_call(ps::ParseState, ret::EXPR, ismacro=false)
         end
     elseif is_and(ret) || is_decl(ret) || is_exor(ret)
         arg = @precedence ps 20 parse_expression(ps)
-        if is_exor(ret) && istuple(arg) && length(arg) == 3 && issplat(arg.args[2])
+        if is_exor(ret) && istuple(arg) && length(arg) == 3 && issplat(arg.args[1])
             arg = EXPR(:brackets, arg.args)
         end
         ret = EXPR(ret, EXPR[arg], nothing)


### PR DESCRIPTION
Fixes off by one indexing of :tuple. No test as I can't work out how this is hit in the way it is supposed to be (e.g. where the single element of a tuple is splatted), I suspect changes in tuple parsing may mean it's nowo unnecessary.