### PR TITLE
fix juxtaposition with end/begin in :ref

### DIFF
--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -23,7 +23,7 @@ function parse_kw(ps::ParseState)
             return @default ps @closer ps :block parse_blockexpr(ps, :begin)
         else
             if ps.closer.inref
-                ret = EXPR(ps)
+                ret = EXPR(:IDENTIFIER, ps)
             else
                 return @default ps @closer ps :block parse_blockexpr(ps, :begin)
             end
@@ -61,7 +61,7 @@ function parse_kw(ps::ParseState)
         return @default ps parse_return(ps)
     elseif k === Tokens.END
         if ps.closer.square
-            ret = EXPR(ps)
+            ret = EXPR(:IDENTIFIER, ps)
         else
             ret = mErrorToken(ps, EXPR(:IDENTIFIER, ps), UnexpectedToken)
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,7 +205,8 @@ end
 isajuxtaposition(ps::ParseState, ret::EXPR) = ((isnumber(ret) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.LPAREN || kindof(ps.nt) === Tokens.CMD || kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)) ||
         ((is_prime(ret.head) && isidentifier(ps.nt)) ||
         ((kindof(ps.t) === Tokens.RPAREN || kindof(ps.t) === Tokens.RSQUARE) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.CMD)) ||
-        ((kindof(ps.t) === Tokens.STRING || kindof(ps.t) === Tokens.TRIPLE_STRING) && (kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)))) || ((kindof(ps.t) in (Tokens.INTEGER, Tokens.FLOAT) || kindof(ps.t) in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)) && isidentifier(ps.nt))
+        ((kindof(ps.t) === Tokens.STRING || kindof(ps.t) === Tokens.TRIPLE_STRING) && (kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)))) || ((kindof(ps.t) in (Tokens.INTEGER, Tokens.FLOAT) || kindof(ps.t) in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)) && isidentifier(ps.nt)) ||
+        (isnumber(ret) && ps.closer.inref && (ps.nt.kind === Tokens.END || ps.nt.kind === Tokens.BEGIN))
 
 """
     has_error(ps::ParseState)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -927,6 +927,6 @@ end""" |> test_expr
     end
 
     @testset "end as id juxt" begin
-        @test test_expr("a[1end]")
+        @test test_expr("a[2begin:1end]")
     end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -925,5 +925,8 @@ end""" |> test_expr
         x2 = CSTParser.minimal_reparse(s0, s1, x0, x1)
         @test CSTParser.comp(x1, x2)
     end
-    
+
+    @testset "end as id juxt" begin
+        @test test_expr("a[1end]")
+    end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -927,6 +927,9 @@ end""" |> test_expr
     end
 
     @testset "end as id juxt" begin
-        @test test_expr("a[2begin:1end]")
+        @test test_expr("a[1end]")
+        if VERSION >= v"1.4"
+            @test test_expr("a[2begin:1end]")
+        end
     end
 end


### PR DESCRIPTION
Fixes part of https://github.com/julia-vscode/julia-vscode/issues/1922

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
