### PR TITLE
don't make :END an :IDENTIFIER in :refs

### DIFF
--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -23,7 +23,7 @@ function parse_kw(ps::ParseState)
             return @default ps @closer ps :block parse_blockexpr(ps, :begin)
         else
             if ps.closer.inref
-                ret = EXPR(:IDENTIFIER, ps)
+                ret = EXPR(ps)
             else
                 return @default ps @closer ps :block parse_blockexpr(ps, :begin)
             end
@@ -61,7 +61,7 @@ function parse_kw(ps::ParseState)
         return @default ps parse_return(ps)
     elseif k === Tokens.END
         if ps.closer.square
-            ret = EXPR(:IDENTIFIER, ps)
+            ret = EXPR(ps)
         else
             ret = mErrorToken(ps, EXPR(:IDENTIFIER, ps), UnexpectedToken)
         end


### PR DESCRIPTION
Fixes #.

For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
