### PR TITLE
fix fp32 conversion

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -102,7 +102,7 @@ end
 
 function Expr_float(x)
     if !startswith(valof(x), "0x") && 'f' in valof(x)
-        return Base.parse(Float32, replace(valof(x), 'f' => 'e'))
+        return Base.parse(Float32, replace(replace(valof(x), 'f' => 'e'), '_' => ""))
     end
     Base.parse(Float64, replace(valof(x), "_" => ""))
 end


### PR DESCRIPTION
Strip underscores from Float32 before conversion

Fixes something from crash reports, should be merged immediately.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
