### PR TITLE
Fix A.a' parsing

### DIFF
--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -445,7 +445,8 @@ function parse_operator(ps::ParseState, ret::EXPR, op::EXPR)
     elseif is_prime(op)
         if isidentifier(ret) || isliteral(ret) ||
             headof(ret) in (:call, :tuple, :brackets, :ref, :vect, :vcat, :hcat, :typed_vcat, :typed_hcat, :comprehension, :typed_comprehension, :curly, :braces, :braces_cat) ||
-            headof(ret) === :do
+            headof(ret) === :do ||
+            is_dot(headof(ret))
             ret = EXPR(op, EXPR[ret], nothing)
         else
             ret = EXPR(:errortoken, EXPR[ret, op])

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -935,6 +935,7 @@ end""" |> test_expr
         @test !CSTParser.has_error(cst"[]'")
         @test !CSTParser.has_error(cst"'a''")
         @test test_expr("(a)'")
+        @test test_expr("a.a'")
     end
     
     @testset "end as id juxt" begin


### PR DESCRIPTION
For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
