### PR TITLE
improve cmd parsing

### DIFF
--- a/src/components/strings.jl
+++ b/src/components/strings.jl
@@ -90,7 +90,7 @@ function parse_string_or_cmd(ps::ParseState, prefixed=false)
         else
             return EXPR(:STRING, sfullspan, sspan, "")
         end
-    elseif prefixed != false || iscmd
+    elseif prefixed != false
         _val = istrip ? t_str[4:prevind(t_str, sizeof(t_str), 3)] : t_str[2:prevind(t_str, sizeof(t_str))]
         if iscmd
             _val = replace(_val, "\\\\" => "\\")

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -170,6 +170,8 @@ function Expr(x::EXPR)
         Expr(:macrocall, new_name, Expr.(x.args[2:end])...)
     elseif x.head === :macrocall && isidentifier(x.args[1]) && valof(x.args[1]) == "@."
         Expr(:macrocall, Symbol("@__dot__"), Expr.(x.args[2:end])...)
+    elseif x.head === :macrocall && length(x.args) == 3 && x.args[1].head === :globalrefcmd && x.args[3].head == :string
+        Expr(:macrocall, Expr(x.args[1]), Expr(x.args[2]), join(valof.(x.args[3])))
     elseif x.head === :string && length(x.args) > 0 && (x.args[1].head === :STRING || x.args[1].head === :TRIPLESTRING) && isempty(valof(x.args[1]))
         # Special conversion needed - the initial text section is treated as empty for the represented string following lowest-common-prefix adjustments, but exists in the source.
         Expr(:string, Expr.(x.args[2:end])...)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -735,6 +735,17 @@ end""" |> test_expr
         @test CSTParser.headof(x[3]) === :errortoken
     end
 
+    @testset "cmd interpolation" begin
+        @test test_expr("`a \$b c`")
+        @test test_expr("`a b c`")
+        x = CSTParser.parse("`a \$b c`")
+        @test x.args[1].head == :globalrefcmd
+        @test x.args[3].head == :string
+        @test valof(x.args[3].args[1]) == "a "
+        @test valof(x.args[3].args[2]) == "b"
+        @test valof(x.args[3].args[3]) == " c"
+    end
+
     @testset "Broken things" begin
         @test_broken "\$(a) * -\$(b)" |> test_expr_broken
     end


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/1654.

This parses cmd strings more like normal string (so we keep track of the interpolated variables). Not sure if this is a good idea because it introduces further differences between `EXPR`s and `Expr`s, but then again we already have a bunch of special cases around cmds so maybe it's fine.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
