### PR TITLE
Fix parsing `A[a~b]`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,7 +28,6 @@ function closer(ps::ParseState)
     (ps.closer.paren && kindof(ps.nt) === Tokens.RPAREN) ||
     (ps.closer.brace && kindof(ps.nt) === Tokens.RBRACE) ||
     (ps.closer.square && kindof(ps.nt) === Tokens.RSQUARE) ||
-    (@static VERSION < v"1.4" ? false : ((ps.closer.insquare || ps.closer.inmacro) && kindof(ps.nt) === Tokens.APPROX && kindof(ps.nws) == EmptyWS)) ||
     kindof(ps.nt) === Tokens.ELSEIF ||
     kindof(ps.nt) === Tokens.ELSE ||
     kindof(ps.nt) === Tokens.CATCH ||

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -718,6 +718,7 @@ end""" |> test_expr
         if VERSION > v"1.1-"
             @test "a .~ b" |> test_expr
         end
+        @test "A[a~b]" |> test_expr
         @test "1 .< 2 .< 3" |> test_expr
         @test "(;)" |> test_expr
         if VERSION > v"1.5"


### PR DESCRIPTION
Fixes #285 

The bug is introduced by https://github.com/julia-vscode/CSTParser.jl/pull/122. I don't really understand why `~` is special when `ps.closer.insquare || ps.closer.inmacro`, so I just removed it. It'd be nice if that PR added tests.