### PR TITLE
fix various iteration issues

### DIFF
--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -232,14 +232,7 @@ function parse_parameters(ps::ParseState, args::Vector{EXPR}, args1::Vector{EXPR
         isfirst = true
     end
     if !isempty(args1)
-        # this happens when multiple semi-colons are used
-        # Julia will error during lowering, so these shenanigans are just for matching
-        # kwarg order with Base's parser
-        if length(args) >= 1 && args[1] isa EXPR && args[1].head == :kw && usekw
-            insert!(args, max(insert_params_at - 1, 1), EXPR(:parameters, args1, trivia))
-        else
-            insert!(args, insert_params_at, EXPR(:parameters, args1, trivia))
-        end
+        insert!(args, insert_params_at, EXPR(:parameters, args1, trivia))
     end
     return
 end

--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -254,7 +254,7 @@ function parse_unary_colon(ps::ParseState, op::EXPR)
         if isoperator(unwrapped) || isidentifier(unwrapped) || isliteral(unwrapped)
             ret = EXPR(:quotenode, EXPR[arg], EXPR[op])
         elseif arg.head == :tuple && length(arg.args) == 1 && arg.args[1].head == :parameters && length(something(arg.args[1].args, [])) == 0 && arg.span > 3
-            ret = EXPR(:quote, EXPR[EXPR(:BLOCK, EXPR[], EXPR[])], EXPR[])
+            ret = EXPR(:quote, EXPR[EXPR(:BLOCK, EXPR[], EXPR[])], EXPR[op])
         else
             ret = EXPR(:quote, EXPR[arg], EXPR[op])
         end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -195,6 +195,20 @@ function Expr(x::EXPR)
         Expr(:string, Expr.(x.args[2:end])...)
     elseif x.args === nothing
         Expr(Symbol(lowercase(String(x.head))))
+    elseif x.head === :parameters
+        if length(x.args) > 1 && any(a -> a.head === :parameters, x.args)
+            ordered_args = EXPR[]
+            for arg in x.args
+                if arg.head === :parameters
+                    pushfirst!(ordered_args, arg)
+                else
+                    push!(ordered_args, arg)
+                end
+            end
+            Expr(:parameters, Expr.(ordered_args)...)
+        else
+            Expr(:parameters, Expr.(x.args)...)
+        end
     elseif x.head === :errortoken
         Expr(:error)
     else

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -8,7 +8,7 @@ function Base.getindex(x::EXPR, i)
             error("indexing error for $(x.head) expression at $i")
         end
         return a
-    catch 
+    catch
         error("indexing error for $(x.head) expression at $i. args: $(x.args !== nothing ? headof.(x.args) : []) trivia: $(x.trivia !== nothing ? headof.(x.trivia) : [])")
     end
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -16,6 +16,18 @@ randop() = rand(["-->", "→",
 
 test_expr_broken(str) = test_expr(str, false)
 
+function traverse(x)
+    try
+        for a in x
+            @test traverse(a)
+        end
+        return true
+    catch err
+        @error "EXPR traversal failed." expr = x exception = err
+        return false
+    end
+end
+
 function test_expr(str, show_data=true)
     x, ps = CSTParser.parse(ParseState(str))
 
@@ -26,6 +38,7 @@ function test_expr(str, show_data=true)
     @test x.trivia === nothing || all(x === parentof(a) for a in x.trivia)
     @test isempty(check_span(x))
     check_parents(x)
+    @test traverse(x)
 
     if CSTParser.has_error(ps) || x0 != x1
         if show_data


### PR DESCRIPTION
This fixes two iteration order issues (kwargs with multiple `;`s and things like `:(;;;)`) I introduced in https://github.com/julia-vscode/CSTParser.jl/pull/291.
Also tests whether iteration over any of the test expressions in `test/parser.jl` throws an error.