### PR TITLE
Params fix

### DIFF
--- a/src/components/internals.jl
+++ b/src/components/internals.jl
@@ -226,7 +226,7 @@ function parse_parameters(ps::ParseState, args::Vector{EXPR}, args1::Vector{EXPR
             push!(trivia, EXPR(:errortoken, EXPR[EXPR(:COMMA, 0, 0)], nothing))
         end
         if kindof(ps.ws) == SemiColonWS
-            parse_parameters(ps, args1; usekw=usekw)
+            parse_parameters(ps, args1, EXPR[], 1; usekw=usekw)
         end
         prevpos = isfirst ? loop_check(ps, prevpos) : position(ps)
         isfirst = true

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -195,20 +195,20 @@ function Expr(x::EXPR)
         Expr(:string, Expr.(x.args[2:end])...)
     elseif x.args === nothing
         Expr(Symbol(lowercase(String(x.head))))
-    elseif x.head === :parameters
-        if length(x.args) > 1 && any(a -> a.head === :parameters, x.args)
-            ordered_args = EXPR[]
-            for arg in x.args
-                if arg.head === :parameters
-                    pushfirst!(ordered_args, arg)
-                else
-                    push!(ordered_args, arg)
-                end
-            end
-            Expr(:parameters, Expr.(ordered_args)...)
-        else
-            Expr(:parameters, Expr.(x.args)...)
-        end
+    # elseif x.head === :parameters
+    #     if length(x.args) > 1 && any(a -> a.head === :parameters, x.args)
+    #         ordered_args = EXPR[]
+    #         for arg in x.args
+    #             if arg.head === :parameters
+    #                 pushfirst!(ordered_args, arg)
+    #             else
+    #                 push!(ordered_args, arg)
+    #             end
+    #         end
+    #         Expr(:parameters, Expr.(ordered_args)...)
+    #     else
+    #         Expr(:parameters, Expr.(x.args)...)
+    #     end
     elseif x.head === :errortoken
         Expr(:error)
     else

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -195,20 +195,6 @@ function Expr(x::EXPR)
         Expr(:string, Expr.(x.args[2:end])...)
     elseif x.args === nothing
         Expr(Symbol(lowercase(String(x.head))))
-    # elseif x.head === :parameters
-    #     if length(x.args) > 1 && any(a -> a.head === :parameters, x.args)
-    #         ordered_args = EXPR[]
-    #         for arg in x.args
-    #             if arg.head === :parameters
-    #                 pushfirst!(ordered_args, arg)
-    #             else
-    #                 push!(ordered_args, arg)
-    #             end
-    #         end
-    #         Expr(:parameters, Expr.(ordered_args)...)
-    #     else
-    #         Expr(:parameters, Expr.(x.args)...)
-    #     end
     elseif x.head === :errortoken
         Expr(:error)
     else

--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -73,7 +73,15 @@ function _getindex(x::EXPR, i)
     elseif headof(x) === :outer
         ta(x, i)
     elseif headof(x) === :parameters
-        if length(x.args) > 1 && headof(x.args[2]) === :parameters
+        if length(x.args) > 1 && headof(x.args[1]) === :parameters
+            if i == length(x)
+                x.args[1]
+            elseif iseven(i)
+                x.trivia[div(i, 2)]
+            else
+                x.args[div(i + 1, 2) + 1]
+            end
+        elseif length(x.args) > 1 && headof(x.args[2]) === :parameters
             if i == length(x)
                 x.args[2]
             elseif i == 1


### PR DESCRIPTION
Fixes #297  - incorrect handling of nested :parameter blocks by ensuring `insert_params_at` is correctly set when calling `parse_parameters` from within itself and fixing iteration for nested parameter blocks.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
