### PR TITLE
rename Expr constructor to to_codeobject

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -127,8 +127,15 @@ end
 
 
 # Expressions
-to_expr(args...) = Expr(args...)
-function to_expr(x::EXPR)
+to_codeobject(args...) = Expr(args...)
+
+"""
+    to_codeobject(x::EXPR)
+
+Convert an `EXPR` into the object that `Meta.parse` would have produced from
+the original string, which could e.g. be an `Expr`, `Symbol`, or literal.
+"""
+function to_codeobject(x::EXPR)
     if isidentifier(x)
         if headof(x) === :NONSTDIDENTIFIER
             if startswith(valof(x.args[1]), "@")
@@ -141,9 +148,9 @@ function to_expr(x::EXPR)
         end
     elseif iskeyword(x)
         if headof(x) === :BREAK
-            return to_expr(:break)
+            return to_codeobject(:break)
         elseif headof(x) === :CONTINUE
-            return to_expr(:continue)
+            return to_codeobject(:continue)
         else
             return Symbol(lowercase(string(headof(x))))
         end
@@ -154,7 +161,7 @@ function to_expr(x::EXPR)
             if x.args === nothing
                 return :(.)
             elseif length(x.args) == 1 && isoperator(x.args[1])
-                return Expr(:(.), to_expr(x.args[1]))
+                return Expr(:(.), to_codeobject(x.args[1]))
             else
                 Expr(:error)
             end
@@ -165,11 +172,11 @@ function to_expr(x::EXPR)
     elseif isliteral(x)
         return _literal_expr(x)
     elseif isbracketed(x)
-        return to_expr(x.args[1])
+        return to_codeobject(x.args[1])
     elseif x.head isa EXPR
-        Expr(to_expr(x.head), to_expr.(x.args)...)
+        Expr(to_codeobject(x.head), to_codeobject.(x.args)...)
     elseif x.head === :quotenode
-        QuoteNode(to_expr(x.args[1]))
+        QuoteNode(to_codeobject(x.args[1]))
     elseif x.head === :globalrefdoc
         GlobalRef(Core, Symbol("@doc"))
     elseif x.head === :globalrefcmd
@@ -183,20 +190,20 @@ function to_expr(x::EXPR)
         valofrhs = valof(x.args[1].args[2].args[1])
         valofrhs = valofrhs === nothing ? "" : valofrhs
         new_name = Expr(:., remove_at(x.args[1].args[1]), QuoteNode(Symbol("@", valofrhs)))
-        Expr(:macrocall, new_name, to_expr.(x.args[2:end])...)
+        Expr(:macrocall, new_name, to_codeobject.(x.args[2:end])...)
     elseif x.head === :macrocall && isidentifier(x.args[1]) && valof(x.args[1]) == "@."
-        Expr(:macrocall, Symbol("@__dot__"), to_expr.(x.args[2:end])...)
+        Expr(:macrocall, Symbol("@__dot__"), to_codeobject.(x.args[2:end])...)
     elseif x.head === :macrocall && length(x.args) == 3 && x.args[1].head === :globalrefcmd && x.args[3].head == :string
-        Expr(:macrocall, to_expr(x.args[1]), to_expr(x.args[2]), x.args[3].meta)
+        Expr(:macrocall, to_codeobject(x.args[1]), to_codeobject(x.args[2]), x.args[3].meta)
     elseif x.head === :string && length(x.args) > 0 && (x.args[1].head === :STRING || x.args[1].head === :TRIPLESTRING) && isempty(valof(x.args[1]))
         # Special conversion needed - the initial text section is treated as empty for the represented string following lowest-common-prefix adjustments, but exists in the source.
-        Expr(:string, to_expr.(x.args[2:end])...)
+        Expr(:string, to_codeobject.(x.args[2:end])...)
     elseif x.args === nothing
         Expr(Symbol(lowercase(String(x.head))))
     elseif x.head === :errortoken
         Expr(:error)
     else
-        Expr(Symbol(lowercase(String(x.head))), to_expr.(x.args)...)
+        Expr(Symbol(lowercase(String(x.head))), to_codeobject.(x.args)...)
     end
 end
 
@@ -206,7 +213,7 @@ function remove_at(x)
     elseif is_getfield_w_quotenode(x)
         Expr(:., remove_at(x.args[1]), QuoteNode(remove_at(x.args[2].args[1])))
     else
-        to_expr(x)
+        to_codeobject(x)
     end
 end
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,5 +1,3 @@
-import Core: Expr
-
 # Terminals
 function julia_normalization_map(c::Int32, x::Ptr{Nothing})::Int32
     return c == 0x00B5 ? 0x03BC : # micro sign -> greek small letter mu
@@ -129,8 +127,8 @@ end
 
 
 # Expressions
-
-function Expr(x::EXPR)
+to_expr(args...) = Expr(args...)
+function to_expr(x::EXPR)
     if isidentifier(x)
         if headof(x) === :NONSTDIDENTIFIER
             if startswith(valof(x.args[1]), "@")
@@ -143,9 +141,9 @@ function Expr(x::EXPR)
         end
     elseif iskeyword(x)
         if headof(x) === :BREAK
-            return Expr(:break)
+            return to_expr(:break)
         elseif headof(x) === :CONTINUE
-            return Expr(:continue)
+            return to_expr(:continue)
         else
             return Symbol(lowercase(string(headof(x))))
         end
@@ -156,7 +154,7 @@ function Expr(x::EXPR)
             if x.args === nothing
                 return :(.)
             elseif length(x.args) == 1 && isoperator(x.args[1])
-                return Expr(:(.), Expr(x.args[1]))
+                return Expr(:(.), to_expr(x.args[1]))
             else
                 Expr(:error)
             end
@@ -167,11 +165,11 @@ function Expr(x::EXPR)
     elseif isliteral(x)
         return _literal_expr(x)
     elseif isbracketed(x)
-        return Expr(x.args[1])
+        return to_expr(x.args[1])
     elseif x.head isa EXPR
-        Expr(Expr(x.head), Expr.(x.args)...)
+        Expr(to_expr(x.head), to_expr.(x.args)...)
     elseif x.head === :quotenode
-        QuoteNode(Expr(x.args[1]))
+        QuoteNode(to_expr(x.args[1]))
     elseif x.head === :globalrefdoc
         GlobalRef(Core, Symbol("@doc"))
     elseif x.head === :globalrefcmd
@@ -185,20 +183,20 @@ function Expr(x::EXPR)
         valofrhs = valof(x.args[1].args[2].args[1])
         valofrhs = valofrhs === nothing ? "" : valofrhs
         new_name = Expr(:., remove_at(x.args[1].args[1]), QuoteNode(Symbol("@", valofrhs)))
-        Expr(:macrocall, new_name, Expr.(x.args[2:end])...)
+        Expr(:macrocall, new_name, to_expr.(x.args[2:end])...)
     elseif x.head === :macrocall && isidentifier(x.args[1]) && valof(x.args[1]) == "@."
-        Expr(:macrocall, Symbol("@__dot__"), Expr.(x.args[2:end])...)
+        Expr(:macrocall, Symbol("@__dot__"), to_expr.(x.args[2:end])...)
     elseif x.head === :macrocall && length(x.args) == 3 && x.args[1].head === :globalrefcmd && x.args[3].head == :string
-        Expr(:macrocall, Expr(x.args[1]), Expr(x.args[2]), x.args[3].meta)
+        Expr(:macrocall, to_expr(x.args[1]), to_expr(x.args[2]), x.args[3].meta)
     elseif x.head === :string && length(x.args) > 0 && (x.args[1].head === :STRING || x.args[1].head === :TRIPLESTRING) && isempty(valof(x.args[1]))
         # Special conversion needed - the initial text section is treated as empty for the represented string following lowest-common-prefix adjustments, but exists in the source.
-        Expr(:string, Expr.(x.args[2:end])...)
+        Expr(:string, to_expr.(x.args[2:end])...)
     elseif x.args === nothing
         Expr(Symbol(lowercase(String(x.head))))
     elseif x.head === :errortoken
         Expr(:error)
     else
-        Expr(Symbol(lowercase(String(x.head))), Expr.(x.args)...)
+        Expr(Symbol(lowercase(String(x.head))), to_expr.(x.args)...)
     end
 end
 
@@ -208,7 +206,7 @@ function remove_at(x)
     elseif is_getfield_w_quotenode(x)
         Expr(:., remove_at(x.args[1]), QuoteNode(remove_at(x.args[2].args[1])))
     else
-        Expr(x)
+        to_expr(x)
     end
 end
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -148,9 +148,9 @@ function to_codeobject(x::EXPR)
         end
     elseif iskeyword(x)
         if headof(x) === :BREAK
-            return to_codeobject(:break)
+            return Expr(:break)
         elseif headof(x) === :CONTINUE
-            return to_codeobject(:continue)
+            return Expr(:continue)
         else
             return Symbol(lowercase(string(headof(x))))
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -441,7 +441,7 @@ function str_value(x)
     elseif isidentifier(x)
         valof(x.args[2])
     elseif isoperator(x)
-        return string(Expr(x))
+        return string(to_expr(x))
     else
         return ""
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -441,7 +441,7 @@ function str_value(x)
     elseif isidentifier(x)
         valof(x.args[2])
     elseif isoperator(x)
-        return string(to_expr(x))
+        return string(to_codeobject(x))
     else
         return ""
     end

--- a/test/check_base.jl
+++ b/test/check_base.jl
@@ -72,7 +72,7 @@ function cst_parse_file(str)
         @error "CST spans inconsistent!"
     end
 
-    x0 = norm_ast(to_expr(x))
+    x0 = norm_ast(to_codeobject(x))
     x0, CSTParser.has_error(ps) || !isempty(sp)
 end
 

--- a/test/check_base.jl
+++ b/test/check_base.jl
@@ -72,7 +72,7 @@ function cst_parse_file(str)
         @error "CST spans inconsistent!"
     end
 
-    x0 = norm_ast(Expr(x))
+    x0 = norm_ast(to_expr(x))
     x0, CSTParser.has_error(ps) || !isempty(sp)
 end
 

--- a/test/errparse.jl
+++ b/test/errparse.jl
@@ -46,7 +46,7 @@
             rethrow(e)
         end
         try
-            to_expr(x)
+            to_codeobject(x)
         catch e
             @info "Couldn't convert:"
             @info s

--- a/test/errparse.jl
+++ b/test/errparse.jl
@@ -46,7 +46,7 @@
             rethrow(e)
         end
         try
-            Expr(x)
+            to_expr(x)
         catch e
             @info "Couldn't convert:"
             @info s

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -5,7 +5,7 @@ function test_iter_spans(x)
     for i = 1:length(x)
         a  = x[i]
         if !(a isa EXPR)
-            @info i, headof(x), Expr(x)
+            @info i, headof(x), to_expr(x)
         end
         @test a isa EXPR
         test_iter_spans(a)

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -5,7 +5,7 @@ function test_iter_spans(x)
     for i = 1:length(x)
         a  = x[i]
         if !(a isa EXPR)
-            @info i, headof(x), to_expr(x)
+            @info i, headof(x), to_codeobject(x)
         end
         @test a isa EXPR
         test_iter_spans(a)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -31,7 +31,7 @@ end
 function test_expr(str, show_data=true)
     x, ps = CSTParser.parse(ParseState(str))
 
-    x0 = Expr(x)
+    x0 = to_expr(x)
     x1 = remlineinfo!(Meta.parse(str))
 
     @test x.args === nothing || all(x === parentof(a) for a in x.args)
@@ -624,10 +624,10 @@ end
         @test valof(CSTParser.parse("\"\"\"a\"\"\"")) == "a"
         @test valof(CSTParser.parse("\"\"\"\"\"\"")) == ""
         @test valof(CSTParser.parse("\"\"\"\n\t \ta\n\n\t \tb\"\"\"")) == "a\n\nb"
-        @test Expr(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
-        @test Expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
-        @test Expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\t\"\"\"")) == Expr(:string, "a\nb ", :c, "\nd\n")
-        @test Expr(CSTParser.parse("\"\"\"\n\t \ta\$(1+\n1)\n\t \tb\"\"\"")) == Expr(:string, "a", :(1 + 1), "\nb")
+        @test to_expr(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
+        @test to_expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
+        @test to_expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\t\"\"\"")) == Expr(:string, "a\nb ", :c, "\nd\n")
+        @test to_expr(CSTParser.parse("\"\"\"\n\t \ta\$(1+\n1)\n\t \tb\"\"\"")) == Expr(:string, "a", :(1 + 1), "\nb")
         ws = "                         "
         "\"\"\"\n$ws%rv = atomicrmw \$rmw \$lt* %0, \$lt %1 acq_rel\n$(ws)ret \$lt %rv\n$ws\"\"\"" |> test_expr
         ws1 = "        "
@@ -1061,7 +1061,7 @@ end
         end
     end
     @testset "bad uint" begin
-        @test Expr(CSTParser.parse("0x.")) == Expr(:error)
+        @test to_expr(CSTParser.parse("0x.")) == Expr(:error)
     end
 
     @testset "endswithtrivia" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -31,7 +31,7 @@ end
 function test_expr(str, show_data=true)
     x, ps = CSTParser.parse(ParseState(str))
 
-    x0 = to_expr(x)
+    x0 = to_codeobject(x)
     x1 = remlineinfo!(Meta.parse(str))
 
     @test x.args === nothing || all(x === parentof(a) for a in x.args)
@@ -624,10 +624,10 @@ end
         @test valof(CSTParser.parse("\"\"\"a\"\"\"")) == "a"
         @test valof(CSTParser.parse("\"\"\"\"\"\"")) == ""
         @test valof(CSTParser.parse("\"\"\"\n\t \ta\n\n\t \tb\"\"\"")) == "a\n\nb"
-        @test to_expr(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
-        @test to_expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
-        @test to_expr(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\t\"\"\"")) == Expr(:string, "a\nb ", :c, "\nd\n")
-        @test to_expr(CSTParser.parse("\"\"\"\n\t \ta\$(1+\n1)\n\t \tb\"\"\"")) == Expr(:string, "a", :(1 + 1), "\nb")
+        @test to_codeobject(CSTParser.parse("\"\"\"\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
+        @test to_codeobject(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\"\"\"")) == Expr(:string, "\ta\n\tb ", :c, "\n\td\n")
+        @test to_codeobject(CSTParser.parse("\"\"\"\n\ta\n\tb \$c\n\td\n\t\"\"\"")) == Expr(:string, "a\nb ", :c, "\nd\n")
+        @test to_codeobject(CSTParser.parse("\"\"\"\n\t \ta\$(1+\n1)\n\t \tb\"\"\"")) == Expr(:string, "a", :(1 + 1), "\nb")
         ws = "                         "
         "\"\"\"\n$ws%rv = atomicrmw \$rmw \$lt* %0, \$lt %1 acq_rel\n$(ws)ret \$lt %rv\n$ws\"\"\"" |> test_expr
         ws1 = "        "
@@ -1061,7 +1061,7 @@ end
         end
     end
     @testset "bad uint" begin
-        @test to_expr(CSTParser.parse("0x.")) == Expr(:error)
+        @test to_codeobject(CSTParser.parse("0x.")) == Expr(:error)
     end
 
     @testset "endswithtrivia" begin

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,4 +1,4 @@
-using CSTParser: @cst_str, headof, parentof, check_span, EXPR
+using CSTParser: @cst_str, headof, parentof, check_span, EXPR, to_expr
 jl_parse(s) = CSTParser.remlineinfo!(Meta.parse(s))
 
 function check_parents(x::EXPR)
@@ -33,7 +33,7 @@ function test_expr(s, head, n, endswithtrivia = false)
     @test length(x) === n
     @test x.args === nothing || all(x === parentof(a) for a in x.args)
     @test x.trivia === nothing || all(x === parentof(a) for a in x.trivia)
-    @test Expr(x) == jl_parse(s)
+    @test to_expr(x) == jl_parse(s)
     @test isempty(check_span(x))
     check_parents(x)
     test_iter(x)
@@ -266,17 +266,17 @@ end
     let s = "``"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == Expr(x)
+        @test x1 == to_expr(x)
     end
     let s = "`a`"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == Expr(x)
+        @test x1 == to_expr(x)
     end
     let s = "`a \$a`"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == Expr(x)
+        @test x1 == to_expr(x)
     end
     test_expr("a``", nothing, 3, false)
     test_expr("a`a`", nothing, 3, false)

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,4 +1,4 @@
-using CSTParser: @cst_str, headof, parentof, check_span, EXPR, to_expr
+using CSTParser: @cst_str, headof, parentof, check_span, EXPR, to_codeobject
 jl_parse(s) = CSTParser.remlineinfo!(Meta.parse(s))
 
 function check_parents(x::EXPR)
@@ -33,7 +33,7 @@ function test_expr(s, head, n, endswithtrivia = false)
     @test length(x) === n
     @test x.args === nothing || all(x === parentof(a) for a in x.args)
     @test x.trivia === nothing || all(x === parentof(a) for a in x.trivia)
-    @test to_expr(x) == jl_parse(s)
+    @test to_codeobject(x) == jl_parse(s)
     @test isempty(check_span(x))
     check_parents(x)
     test_iter(x)
@@ -266,17 +266,17 @@ end
     let s = "``"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == to_expr(x)
+        @test x1 == to_codeobject(x)
     end
     let s = "`a`"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == to_expr(x)
+        @test x1 == to_codeobject(x)
     end
     let s = "`a \$a`"
         x = CSTParser.parse(s)
         x1 = jl_parse(s)
-        @test x1 == to_expr(x)
+        @test x1 == to_codeobject(x)
     end
     test_expr("a``", nothing, 3, false)
     test_expr("a`a`", nothing, 3, false)


### PR DESCRIPTION
Fixes #308.

Should probably rename this to `to_exprlike` (`base_parse` might be more accurate?) or something like that, unless someone can come up with a better name.