### PR TITLE
Unmagicify isjuxtaposition

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,12 +205,13 @@ macro default(ps, body)
     end
 end
 
-
-isajuxtaposition(ps::ParseState, ret::EXPR) = ((isnumber(ret) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.LPAREN || kindof(ps.nt) === Tokens.CMD || kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)) ||
-        ((is_prime(ret.head) && isidentifier(ps.nt)) ||
-        ((kindof(ps.t) === Tokens.RPAREN || kindof(ps.t) === Tokens.RSQUARE) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.CMD)) ||
-        ((kindof(ps.t) === Tokens.STRING || kindof(ps.t) === Tokens.TRIPLE_STRING) && (kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)))) || ((kindof(ps.t) in (Tokens.INTEGER, Tokens.FLOAT) || kindof(ps.t) in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)) && isidentifier(ps.nt)) ||
-        (isnumber(ret) && ps.closer.inref && (ps.nt.kind === Tokens.END || ps.nt.kind === Tokens.BEGIN))
+isajuxtaposition(ps::ParseState, ret::EXPR) =
+    (isnumber(ret) && (isidentifier(ps.nt) || (kindof(ps.nt) === JuX.LPAREN || (kindof(ps.nt) === JuX.CMD || (kindof(ps.nt) === JuX.STRING || kindof(ps.nt) === JuX.TRIPLE_STRING))))) ||
+    (is_prime(ret.head) && isidentifier(ps.nt)) ||
+    ((kindof(ps.t) === JuX.RPAREN || kindof(ps.t) === JuX.RSQUARE) && (isidentifier(ps.nt) || kindof(ps.nt) === JuX.CMD)) ||
+    ((kindof(ps.t) === JuX.STRING || kindof(ps.t) === JuX.TRIPLE_STRING) && (kindof(ps.nt) === JuX.STRING || kindof(ps.nt) === JuX.TRIPLE_STRING)) ||
+    ((kindof(ps.t) in (JuX.INTEGER, JuX.FLOAT) || kindof(ps.t) in (JuX.RPAREN, JuX.RSQUARE, JuX.RBRACE)) && isidentifier(ps.nt)) ||
+    (isnumber(ret) && (ps.closer.inref && (ps.nt.kind === JuX.END || ps.nt.kind === JuX.BEGIN)))
 
 """
     has_error(ps::ParseState)


### PR DESCRIPTION
isajuxtaposition is very complex eg. unreadable and unmaintainable.
It mainly consists of an unflattened big or chain

```julia
using Test
@test x.head===:|| && length(x.args)==2
    @test x.args[1].head===:|| && length(x.args[1].args)==2
        @test x.args[1].args[2].head===:|| && length(x.args[1].args[2].args)==2
    @test x.args[2].head==:|| && length(x.args[2].args)==2
```

that can be refactored into the new proposed one with the help of
```julia
import Base.Meta: Expr, isexpr
"""
flatten nested expressions with the given head
(op (op a b) c) => (op a b c)
"""
flatten_expr(_, a) = a
flatten_expr(head, x::Expr) = begin
    av = map(x.args) do xa
        isexpr(xa, head) ?
            flatten_expr(head,xa) |> x->x.args :
            Any[xa]
    end
    Expr(x.head, append!(av...)...)
end
```

translated from https://github.com/JuliaLang/julia/blob/v1.6.3/src/ast.scm#L515-L526

## Proof

```julia
x0 = :(
isajuxtaposition(ps::ParseState, ret::EXPR) = ((isnumber(ret) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.LPAREN || kindof(ps.nt) === Tokens.CMD || kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)) ||
    ((is_prime(ret.head) && isidentifier(ps.nt)) ||
    ((kindof(ps.t) === Tokens.RPAREN || kindof(ps.t) === Tokens.RSQUARE) && (isidentifier(ps.nt) || kindof(ps.nt) === Tokens.CMD)) ||
    ((kindof(ps.t) === Tokens.STRING || kindof(ps.t) === Tokens.TRIPLE_STRING) && (kindof(ps.nt) === Tokens.STRING || kindof(ps.nt) === Tokens.TRIPLE_STRING)))) || ((kindof(ps.t) in (Tokens.INTEGER, Tokens.FLOAT) || kindof(ps.t) in (Tokens.RPAREN, Tokens.RSQUARE, Tokens.RBRACE)) && isidentifier(ps.nt)) ||
    (isnumber(ret) && ps.closer.inref && (ps.nt.kind === Tokens.END || ps.nt.kind === Tokens.BEGIN))
)
x = x0.args[2].args[2] # function body without quote

x2 = flatten_expr(:||, x)

@test length(x2.args) == 6

_unlower_flattened_or(x::Expr) = let xas = reverse(x.args);
    foldl(xas[2:end]; init=xas[1]) do xacc,xv; :($xv || $xacc) end
end

x2 |> _unlower_flattened_or # will print the new body
```

