### PR TITLE
Adjust global const parsing

### DIFF
--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -99,7 +99,7 @@ function parse_local_global(ps::ParseState, islocal = true)
     kw = EXPR(ps)
     if ps.nt.kind === Tokens.CONST
         arg1 = parse_const(next(ps))
-        EXPR(:const, EXPR[EXPR(islocal ? :local : :global, EXPR[arg1.args[1]], nothing)], EXPR[kw, arg1.trivia[1]])
+        EXPR(:const, EXPR[EXPR(islocal ? :local : :global, arg1.args, EXPR[kw])], arg1.trivia)
     else
         args, trivia = EXPR[], EXPR[kw]
         arg = parse_expression(ps)

--- a/test/iterate.jl
+++ b/test/iterate.jl
@@ -37,12 +37,12 @@ end
         end
         @testset "simple" begin
             x = cst"global const a = 1"
-            @test length(x) == 3
+            @test length(x) == 2
             @test x[1] === x.trivia[1]
-            @test x[2] === x.trivia[2]
-            @test x[3] === x.args[1]
-            @test length(x[3]) == 1
-            @test x[3][1] === x.args[1].args[1]
+            @test x[2] === x.args[1]
+            @test length(x[2]) == 2
+            @test x[2][1] === x.args[1].trivia[1]
+            @test x[2][2] === x.args[1].args[1]
         end
 
         @testset "return" begin

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -49,8 +49,8 @@ end
     test_expr("global a", :global, 2)
     test_expr("global a, b", :global, 4)
     test_expr("global a, b = 2", :global, 2)
-    test_expr("global const a = 1", :const, 3)
-    test_expr("global const a = 1, b", :const, 3)
+    test_expr("global const a = 1", :const, 2)
+    test_expr("global const a = 1, b", :const, 2)
 end
 
 @testset ":const" begin


### PR DESCRIPTION
to match const global parsing.

Fixes https://github.com/julia-vscode/CSTParser.jl/issues/342.
