### PR TITLE
Add diagnostics for CSTParser indexing bug

### DIFF
--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -717,6 +717,9 @@ function _vcat(x, i)
         x.trivia[1]
     elseif i == length(x)
         x.trivia[2]
+    elseif (i-1) > length(x.args)
+        # TODO Remove once we have figured out what is causing this bug
+        error("Illegal indexing into CSTParser. x.head: '$(x.head)', x.trivia: '$(x.trivia)', x.args: '$(x.args)'.")
     else
         x.args[i - 1]
     end


### PR DESCRIPTION
We have this crash on insider, so I would suggest we ship this on insider, look at the crash report, try to fix things and then remove again.