### PR TITLE
Don't consume RSQUAREs when closer.square is true

### DIFF
--- a/src/CSTParser.jl
+++ b/src/CSTParser.jl
@@ -44,7 +44,11 @@ function parse_expression(ps::ParseState, esc_on_error = false)
     elseif (esc_on_error && ps.nt.kind == Tokens.ERROR)
         ret = EXPR(:errortoken, 0, 0)
     elseif kindof(ps.nt) ∈ term_c && !(kindof(ps.nt) === Tokens.END && ps.closer.square)
-        ret = mErrorToken(ps, EXPR(next(ps)), UnexpectedToken)
+        if ps.closer.square && kindof(ps.nt) === Tokens.RSQUARE
+            ret = mErrorToken(ps, UnexpectedToken)
+        else
+            ret = mErrorToken(ps, EXPR(next(ps)), UnexpectedToken)
+        end
     else
         next(ps)
         if iskeyword(kindof(ps.t)) && kindof(ps.t) != Tokens.DO

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -478,6 +478,8 @@ end
             @test "[(1,2)]" |> test_expr
             @test "[x...]" |> test_expr
             @test "[1,2,3,4,5]" |> test_expr
+            # this is nonsensical, but iteration should still work
+            @test traverse(CSTParser.parse(raw"""[[:alpha:]a←-]"""))
         end
 
         @testset "ref" begin


### PR DESCRIPTION
Fixes a case of that fun `cat` indexing bug.