### PR TITLE
Fix parsing of unterminated brackets

### DIFF
--- a/src/components/lists.jl
+++ b/src/components/lists.jl
@@ -151,6 +151,9 @@ function parse_array_outer(ps::ParseState, trivia, isref)
                 push!(trivia, accept_comma(ps))
                 @closesquare ps parse_comma_sep(ps, args, trivia, isref, insert_params_at = 1)
                 return EXPR(:vect, args, trivia)
+            elseif kindof(ps.nt) === Tokens.ENDMARKER
+                push!(args, a)
+                return EXPR(:vect, args, trivia)
             end
         end
         is_start = false

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -480,6 +480,13 @@ end
             @test "[1,2,3,4,5]" |> test_expr
             # this is nonsensical, but iteration should still work
             @test traverse(CSTParser.parse(raw"""[[:alpha:]a←-]"""))
+            # unterminated expressions may cause issues
+            @test traverse(CSTParser.parse("bind_artifact!(\"../Artifacts.toml\",\"example\",hash,download_info=[(\"file://c:/juliaWork/tarballs/example.tar.gz\"\",tarball_hash)],force=true)\n2+2\n"))
+            @test traverse(CSTParser.parse("[2+3+4"))
+            @test traverse(CSTParser.parse("[2+3+4+"))
+            @test traverse(CSTParser.parse("[\"hi\"\""))
+            @test traverse(CSTParser.parse("[\"hi\"\"\n"))
+            @test traverse(CSTParser.parse("[(1,2,3])"))
         end
 
         @testset "ref" begin


### PR DESCRIPTION
Hopefully fixes a bunch of issues from crash reporting as well as https://discourse.julialang.org/t/language-server-crash-after-recent-vscode-update/85844.