### PR TITLE
fix: correctly abort macro parsing in dotted generators

### DIFF
--- a/src/components/operators.jl
+++ b/src/components/operators.jl
@@ -384,13 +384,13 @@ function parse_operator_dot(ps::ParseState, ret::EXPR, op::EXPR)
     if kindof(ps.nt) === Tokens.LPAREN
         @static if VERSION > v"1.1-"
             iserred = kindof(ps.ws) != Tokens.EMPTY_WS
-            sig = @default ps parse_call(ps, ret)
+            sig = @default ps @closer ps :for_generator parse_call(ps, ret)
             nextarg = EXPR(:tuple, sig.args[2:end], sig.trivia)
             if iserred
                 nextarg = mErrorToken(ps, nextarg, UnexpectedWhiteSpace)
             end
         else
-            sig = @default ps parse_call(ps, ret)
+            sig = @default ps @closer ps :for_generator parse_call(ps, ret)
             nextarg = EXPR(:tuple, sig.args[2:end], sig.trivia)
         end
     elseif iskeyword(ps.nt) || both_symbol_and_op(ps.nt)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -464,6 +464,8 @@ end
         @test ":(@foo bar baz bat)" |> test_expr
         @test ":(@foo bar for i in j end)" |> test_expr
         @test "(@foo bar for i in j end)" |> test_expr
+        @test "foo(@foo bar for i in j)" |> test_expr
+        @test "foo.(@foo bar for i in j)" |> test_expr
         @test CSTParser.parse("@__DIR__\n\nx", true)[1].span == 8
 
         if VERSION >= v"1.8.0-"


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/CSTParser.jl/issues/368.