### PR TITLE
Support bracketed function call in function definition

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -173,7 +173,9 @@ function get_sig(x::EXPR)
         return x.args[1]
     elseif headof(x) === :struct || headof(x) === :mutable
         return x.args[2]
-    elseif headof(x) === :abstract || headof(x) === :primitive || headof(x) === :function || headof(x) === :macro
+    elseif headof(x) === :function || headof(x) === :macro
+        return rem_invis(x.args[1])
+    elseif headof(x) === :abstract || headof(x) === :primitive
         return x.args[1]
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -575,7 +575,7 @@ _kw_convert(x::EXPR) = EXPR(:kw, EXPR[x.args[1], x.args[2]], EXPR[x.head], x.ful
 
 When parsing a function or macro signature, should it be converted to a tuple?
 """
-convertsigtotuple(sig::EXPR) = isbracketed(sig) && !(istuple(sig.args[1]) || (headof(sig.args[1]) === :block) || issplat(sig.args[1]))
+convertsigtotuple(sig::EXPR) = isbracketed(sig) && !(istuple(sig.args[1]) || (headof(sig.args[1]) === :block) || issplat(sig.args[1]) || iscall(sig.args[1]))
 
 """
     docable(head)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -575,7 +575,7 @@ _kw_convert(x::EXPR) = EXPR(:kw, EXPR[x.args[1], x.args[2]], EXPR[x.head], x.ful
 
 When parsing a function or macro signature, should it be converted to a tuple?
 """
-convertsigtotuple(sig::EXPR) = isbracketed(sig) && !(istuple(sig.args[1]) || (headof(sig.args[1]) === :block) || issplat(sig.args[1]) || iscall(sig.args[1]))
+convertsigtotuple(sig::EXPR) = isbracketed(sig) && !(istuple(sig.args[1]) || iscall(sig.args[1]) || (headof(sig.args[1]) === :block) || issplat(sig.args[1]))
 
 """
     docable(head)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -52,10 +52,12 @@ end
     @test valof(CSTParser.get_name(CSTParser.parse("function f()::T end"))) == "f"
     @test valof(CSTParser.get_name(CSTParser.parse("function f(x::T) where T end"))) == "f"
     @test valof(CSTParser.get_name(CSTParser.parse("function f{T}() end"))) == "f"
+    @test valof(CSTParser.get_name(CSTParser.parse("function (f()) end"))) == "f"
 
     # Operators
     @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("function +() end"))) == "+"
     @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("function (+)() end"))) == "+"
+    @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("function (a + b) end"))) == "+"
     @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("+(x,y) = x"))) == "+"
     @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("+(x,y)::T = x"))) == "+"
     @test CSTParser.str_value(CSTParser.get_name(CSTParser.parse("!(x)::T = x"))) == "!"


### PR DESCRIPTION
The following syntax:

```julia
function (f(a, b))
end
```

was interpreted as an anonymous function with 1 argument of name `f(a,b)`.
This commits allows this syntax as a function `f` with two arguments.

This happened to me in the following case where the references to `a`
where resolved as global `a` (instead of as an argument):

```julia
function (a + b)
    a
end
```

### Before (LanguageServer on neovim)

![Screenshot from 2023-02-22 18-11-04](https://user-images.githubusercontent.com/9824244/220705537-1c434a2a-e3fc-486c-a1aa-038ae9c54bbb.png)


### After (LanguageServer on neovim, highlighting by setting the cursor on the second `b`)

![Screenshot from 2023-02-22 18-14-13](https://user-images.githubusercontent.com/9824244/220705551-bcec3f0f-6b5d-4ab7-b68c-3f1c982c5c3f.png)


For every PR, please check the following:
- [ ] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [ ] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
