### PR TITLE
fix: correctly handle suffixed string macros with mod access

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -659,7 +659,23 @@ end
 
 function issuffixableliteral(ps::ParseState, x::EXPR)
     # prefixed string/cmd macros can be suffixed by identifiers or numeric literals
-    (isidentifier(ps.nt) || isnumberliteral(ps.nt) || isbool(ps.nt)) && isemptyws(ps.ws) && ismacrocall(x) && (valof(x.args[1]) isa String && (endswith(valof(x.args[1]), "_str") || endswith(valof(x.args[1]), "_cmd")))
+    return (
+            isidentifier(ps.nt) ||
+            isnumberliteral(ps.nt) ||
+            isbool(ps.nt)
+        ) &&
+        isemptyws(ps.ws) &&
+        ismacrocall(x) &&
+        (
+            (
+            valof(x.args[1]) isa String &&
+            (endswith(valof(x.args[1]), "_str") || endswith(valof(x.args[1]), "_cmd"))
+            ) ||
+            (
+                is_getfield(x.args[1]) && x.args[1].args[2] isa EXPR && x.args[1].args[2].head in (:quote, :quotenode) &&
+                (endswith(valof(x.args[1].args[2].args[1]), "_str") || endswith(valof(x.args[1].args[2].args[1]), "_cmd"))
+            )
+        )
 end
 
 function loop_check(ps, prevpos)

--- a/test/parser/test_parser.jl
+++ b/test/parser/test_parser.jl
@@ -867,6 +867,7 @@ end
     include("../shared.jl")
 
     @test test_expr(raw"""test"asd"asd""")
+    @test test_expr(raw"""Mod.test"asd"asd""")
     if VERSION >= v"1.6"
         @test test_expr(raw"""test"asd"0""")
         @test test_expr(raw"""test"asd"0o0""")


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/CSTParser.jl/issues/371.