### PR TITLE
fix: correctly iterate over `global (a,b,)`

### DIFF
--- a/src/iterate.jl
+++ b/src/iterate.jl
@@ -261,7 +261,12 @@ function _global(x, i)
         if i <= 2
             x.trivia[i]
         elseif isodd(i)
-            x.args[div(i - 1, 2)]
+            ai = div(i - 1, 2)
+            if ai > length(x.args) # trailing comma
+                x.trivia[div(i - 1, 2) + 2]
+            else
+                x.args[ai]
+            end
         else
             x.trivia[div(i - 2, 2) + 2]
         end

--- a/test/iterate/test_iterators.jl
+++ b/test/iterate/test_iterators.jl
@@ -2,7 +2,7 @@ using CSTParser: @cst_str, headof, valof
 
 @testitem "const local global return.local" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"local a = 1"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -11,7 +11,7 @@ end
 
 @testitem "const local global return.global" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"global a = 1"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -20,7 +20,7 @@ end
 
 @testitem "const local global return.global tuple" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"global (a = 1,b = 2)"
     @test length(x) == 6
     @test x[1] === x.trivia[1]
@@ -31,9 +31,23 @@ end
     @test x[6] === x.trivia[4]
 end
 
+@testitem "const local global return.global tuple trailing comma" begin
+    using CSTParser: @cst_str, headof, valof
+
+    x = cst"global (a = 1,b = 2,)"
+    @test length(x) == 7
+    @test x[1] === x.trivia[1]
+    @test x[2] === x.trivia[2]
+    @test x[3] === x.args[1]
+    @test x[4] === x.trivia[3]
+    @test x[5] === x.args[2]
+    @test x[6] === x.trivia[4]
+    @test x[7] === x.trivia[5]
+end
+
 @testitem "const local global return.const" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"const a = 1"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -41,7 +55,7 @@ end
 end
 @testitem "const local global return.simple" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"global const a = 1"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -53,7 +67,7 @@ end
 
 @testitem "const local global return.return" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"return a"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -62,7 +76,7 @@ end
 
 @testitem "datatype declarations.abstract" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"abstract type T end"
     @test length(x) == 4
     @test x[1] === x.trivia[1]
@@ -73,7 +87,7 @@ end
 
 @testitem "datatype declarations.primitive" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"primitive type T N end"
     @test length(x) == 5
     @test x[1] === x.trivia[1]
@@ -85,7 +99,7 @@ end
 
 @testitem "datatype declarations.struct" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"struct T body end"
     @test length(x) == 5
     @test x[1] === x.trivia[1]
@@ -97,7 +111,7 @@ end
 
 @testitem "datatype declarations.mutable" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"mutable struct T body end"
     @test length(x) == 6
     @test x[1] === x.trivia[1]
@@ -110,7 +124,7 @@ end
 
 @testitem "quote.block" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""quote
                     ex1
                     ex2
@@ -123,7 +137,7 @@ end
 
 @testitem "quote.op" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst""":(body + 1)"""
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -132,7 +146,7 @@ end
 
 @testitem "block.begin" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""begin
                     ex1
                     ex2
@@ -146,7 +160,7 @@ end
 
 @testitem ":for" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""for itr in itr
                     ex1
                     ex2
@@ -160,7 +174,7 @@ end
 
 @testitem ":outer" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""for outer itr in itr
                     ex1
                     ex2
@@ -173,7 +187,7 @@ end
 
 @testitem "function.name only" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""function name end"""
     @test length(x) == 3
     @test x[1] === x.trivia[1]
@@ -183,7 +197,7 @@ end
 
 @testitem "function.full" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"""function sig()
                     ex1
                     ex2
@@ -197,7 +211,7 @@ end
 
 @testitem "braces.simple" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"{a,b,c}"
     @test length(x) == 7
     @test x[1] === x.trivia[1]
@@ -211,7 +225,7 @@ end
 
 @testitem "braces.params" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"{a,b;c}"
     @test length(x) == 6
     @test x[1] === x.trivia[1]
@@ -224,7 +238,7 @@ end
 
 @testitem "curly.simple" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"x{a,b}"
     @test length(x) == 6
     @test x[1] === x.args[1]
@@ -237,7 +251,7 @@ end
 
 @testitem "curly.params" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"x{a,b;c}"
     @test length(x) == 7
     @test x[1] === x.args[1]
@@ -251,7 +265,7 @@ end
 
 @testitem ":comparison" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"a < b < c"
     @test length(x) == 5
     @test x[1] === x.args[1]
@@ -263,7 +277,7 @@ end
 
 @testitem "using.:using" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"using a"
     @test length(x) == 2
     @test x[1] === x.trivia[1]
@@ -291,7 +305,7 @@ end
 
 @testitem "using.:" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"using a: b, c".args[1]
     @test length(x) == 5
     @test x[1] === x.args[1]
@@ -302,7 +316,7 @@ end
 
 @testitem "using.." begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"using a".args[1]
     @test length(x) == 1
     @test x[1] === x.args[1]
@@ -340,7 +354,7 @@ end
 
 @testitem ":kw" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"f(a=1)".args[2]
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -350,7 +364,7 @@ end
 
 @testitem ":tuple" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"a,b"
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -377,7 +391,7 @@ end
 
 @testitem ":call" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"f()"
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -430,7 +444,7 @@ end
 
 @testitem ":where" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"a where {b,c;d}"
     @test length(x) == 8
     @test x[1] === x.args[1]
@@ -445,7 +459,7 @@ end
 
 @testitem ":quotenode" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"a.b".args[2]
     @test length(x) == 1
     @test x[1] === x.args[1]
@@ -458,7 +472,7 @@ end
 
 @testitem ":if" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"if cond end"
     @test length(x) == 4
     @test headof(x[1]) === :IF
@@ -494,7 +508,7 @@ end
 
 @testitem ":elseif" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"if cond elseif c args end".args[3]
     @test length(x) == 3
     @test headof(x[1]) === :ELSEIF
@@ -512,7 +526,7 @@ end
 
 @testitem ":string" begin
     using CSTParser: @cst_str, headof, valof, EXPR
-    
+
     x = cst"\"txt$interp txt\""
     @test length(x) == 4
     @test x[1] === x.args[1]
@@ -598,7 +612,7 @@ end
 
 @testitem ":macrocall" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"@mac a"
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -646,7 +660,7 @@ end
 
 @testitem ":brackets" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"(x)"
     @test length(x) == 3
     @test x[1] === x.trivia[1]
@@ -656,7 +670,7 @@ end
 
 @testitem ":ref" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"x[i]"
     @test length(x) == 4
     @test x[1] === x.args[1]
@@ -686,7 +700,7 @@ end
 
 @testitem ":typed_vcat" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"x[i;j]"
     @test length(x) == 5
     @test x[1] === x.args[1]
@@ -698,7 +712,7 @@ end
 
 @testitem ":row" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"[a b; c d ]".args[1]
     @test length(x) == 2
     @test x[1] === x.args[1]
@@ -707,7 +721,7 @@ end
 
 @testitem ":module" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"module a end"
     @test length(x) == 5
     @test x[1] === x.trivia[1]
@@ -719,7 +733,7 @@ end
 
 @testitem ":export" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"export a, b, c"
     @test length(x) == 6
     @test x[1] === x.trivia[1]
@@ -732,7 +746,7 @@ end
 
 @testitem ":parameters" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"f(a; b=1, c=1, d=1)"[4]
     @test length(x) == 5
     @test x[1] === x.args[1]
@@ -744,7 +758,7 @@ end
 
 @testitem "lowered iterator" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"for a in b end".args[1]
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -754,7 +768,7 @@ end
 
 @testitem ":do" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"f(x) do arg something end"
     @test length(x) == 4
     @test x[1] === x.args[1]
@@ -765,7 +779,7 @@ end
 
 @testitem ":generator" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"(a for a in A)".args[1]
     @test length(x) == 3
     @test x[1] === x.args[1]
@@ -783,7 +797,7 @@ end
 
 @testitem ":flatten" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     function flatten(x)
         if length(x) == 0
             [x]
@@ -805,7 +819,7 @@ end
 
 @testitem ":filter" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"(a for a in A if a)".args[1].args[2]
     @test length(x) == 3
     @test valof(headof(x[1])) == "="
@@ -815,7 +829,7 @@ end
 
 @testitem ":try" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"try expr catch e end"
     @test length(x) == 6
     @test headof(x[1]) === :TRY
@@ -851,7 +865,7 @@ end
 
 @testitem ":comprehension" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"[a for a in A]"
     @test length(x) == 3
     @test headof(x[1]) === :LSQUARE
@@ -861,7 +875,7 @@ end
 
 @testitem ":typed_comprehension" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"T[a for a in A]"
     @test length(x) == 4
     @test headof(x[1]) === :IDENTIFIER
@@ -872,7 +886,7 @@ end
 
 @testitem "unary syntax" begin
     using CSTParser: @cst_str, headof, valof
-    
+
     x = cst"<:a"
     @test length(x) == 2
     @test headof(x[1]) === :OPERATOR


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/CSTParser.jl/issues/372.