### PR TITLE
Change `ParseState` to use a `Memory{T}` on Julia v1.11+

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -27,8 +27,10 @@ mutable struct Closer
 end
 Closer() = Closer(true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, -1)
 
+const ParseStateBufferMem = VERSION >= v"1.11" ? Memory{UInt8} : Vector{UInt8}
+
 mutable struct ParseState
-    l::Lexer{Base.GenericIOBuffer{Array{UInt8,1}},RawToken}
+    l::Lexer{Base.GenericIOBuffer{ParseStateBufferMem},RawToken}
     done::Bool # Remove this
     lt::RawToken
     t::RawToken


### PR DESCRIPTION
Julia v1.11 introduced the `Memory{T}` type, which is slowly but surely replacing some internal datastructures.  Without this change, precompiling `CSTParser.jl` fails with:

```
MethodError: Cannot `convert` an object of type
  Tokenize.Lexers.Lexer{Base.GenericIOBuffer{Memory{UInt8}},Tokenize.Tokens.RawToken} to an object of type
 Tokenize.Lexers.Lexer{Base.GenericIOBuffer{Vector{UInt8}},Tokenize.Tokens.RawToken}
  The function `convert` exists, but no method is defined for this combination of argument types.
```