### PR TITLE
public is allowed as function name in toplevel

### DIFF
--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -73,7 +73,7 @@ function parse_kw(ps::ParseState; is_toplevel = false)
     elseif k === Tokens.PRIMITIVE
         return @default ps parse_primitive(ps)
     elseif k === Tokens.PUBLIC
-        if is_toplevel && ps.nt.kind !== Tokens.LPAREN && VERSION > v"1.11-"
+        if is_toplevel && !isemptyws(ps.ws) && VERSION > v"1.11-"
             return @default ps parse_public(ps)
         else
             return EXPR(:IDENTIFIER, ps)

--- a/src/components/keywords.jl
+++ b/src/components/keywords.jl
@@ -73,7 +73,7 @@ function parse_kw(ps::ParseState; is_toplevel = false)
     elseif k === Tokens.PRIMITIVE
         return @default ps parse_primitive(ps)
     elseif k === Tokens.PUBLIC
-        if is_toplevel && VERSION > v"1.11-"
+        if is_toplevel && ps.nt.kind !== Tokens.LPAREN && VERSION > v"1.11-"
             return @default ps parse_public(ps)
         else
             return EXPR(:IDENTIFIER, ps)

--- a/test/parser/test_keyword_blocks.jl
+++ b/test/parser/test_keyword_blocks.jl
@@ -202,6 +202,8 @@ if VERSION > v"1.11-"
         bar
         """ |> test_expr
         @test "f() = public" |> test_expr
+        @test "public(x) = 1" |> test_expr
+        @test "public(x)" |> test_expr
         @test """
         let
             public


### PR DESCRIPTION
This PR further restrict the public handling by check if it follows a `(`.
`function public...` or `macro public...` should be fine as they are not in toplevel.