### PR TITLE
Accept keyword and operator words as string macro suffixes

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -695,11 +695,20 @@ macro cst_str(x)
 end
 
 function issuffixableliteral(ps::ParseState, x::EXPR)
-    # prefixed string/cmd macros can be suffixed by identifiers or numeric literals
+    # Prefixed string/cmd macros can be suffixed by identifiers or numeric literals.
+    #
+    # Julia treats *any* word directly following the literal as the suffix, keywords and
+    # operator-words included: `r"x"ims`, but equally `r"x"isa`, `r"x"in` and `r"x"end`.
+    # Tokenize hands those last ones back as operator or keyword tokens rather than
+    # identifiers, so they have to be admitted explicitly. Base relies on this — 1.13's
+    # `binaryplatforms.jl` has `r"^(.*?)(?:-((?:[\.\d]+)*))?\.dll$"isa`, which we
+    # otherwise fail to parse.
     return (
             isidentifier(ps.nt) ||
             isnumberliteral(ps.nt) ||
-            isbool(ps.nt)
+            isbool(ps.nt) ||
+            both_symbol_and_op(ps.nt) ||
+            iskeyword(ps.nt)
         ) &&
         isemptyws(ps.ws) &&
         ismacrocall(x) &&


### PR DESCRIPTION
Julia treats **any** word directly following a string or cmd literal as the macro's suffix — keywords and operator-words included:

```julia
julia> Meta.parse.(["r\"x\"ims", "r\"x\"isa", "r\"x\"in", "r\"x\"end", "r\"x\"where"])
:(r"x"ims)   :(r"x"isa)   :(r"x"in)   :(r"x"end)   :(r"x"where)
```

Tokenize returns `isa` / `in` / `where` / keywords as operator or keyword tokens rather than identifiers, and `issuffixableliteral` only admitted identifiers, numbers and bools. So CSTParser reported a parse error on input Julia parses fine:

```julia
CSTParser.parse("r\"x\"ims")   # err = false
CSTParser.parse("r\"x\"isa")   # err = true   ← wrong
```

## Why now

This is long-standing, not a 1.13 regression — the repro above errors identically on 1.12.7 and 1.13.0-rc3. It surfaced because Julia 1.13's `base/binaryplatforms.jl` added

```julia
dlregex = r"^(.*?)(?:-((?:[\.\d]+)*))?\.dll$"isa
```

so the `Parsing files in Base` test started failing on 1.13 with *"CSTParser.parse errored, but Meta.parse didn't"*.

## Safety

`isemptyws(ps.ws)` is already required by `issuffixableliteral`, so this cannot swallow a genuine `in` / `isa` / `where` operator — those need whitespace after the literal, exactly as Julia itself requires. Verified that `a in b`, `x isa Int`, `f(x) where {T}` and `for i in 1:3 end` are unaffected.

## Verification

| Workers | Before | After |
|---|---|---|
| 1.13.0-rc3 | 183 passed, 1 failed | **184 passed** |
| 1.12.7 | 184 passed | **184 passed** |

The underlying lexing is arguably Tokenize's to fix (`JuliaLang/Tokenize.jl` hands back `OP` where Julia's lexer would produce the suffix), but that is an upstream package on a separate release cycle, and the parser can correctly account for it here.